### PR TITLE
feat: Kases API with CRUD endpoints and integration tests

### DIFF
--- a/src/KaseLog.Api/Controllers/KasesController.cs
+++ b/src/KaseLog.Api/Controllers/KasesController.cs
@@ -1,0 +1,57 @@
+using KaseLog.Api.Data;
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KaseLog.Api.Controllers;
+
+[ApiController]
+[Route("api/kases")]
+public sealed class KasesController : ControllerBase
+{
+    private readonly IKaseRepository _kases;
+
+    public KasesController(IKaseRepository kases) => _kases = kases;
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var kases = await _kases.GetAllAsync();
+        return Ok(ApiResponse<IEnumerable<KaseResponse>>.Success(kases));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateKaseRequest request)
+    {
+        var kase = await _kases.CreateAsync(request.Title, request.Description);
+        return CreatedAtAction(nameof(GetById), new { id = kase.Id },
+            ApiResponse<KaseResponse>.Success(kase));
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var kase = await _kases.GetByIdAsync(id);
+        if (kase is null)
+            return NotFound(ApiResponse<KaseResponse>.NotFound($"Kase with ID '{id}' was not found."));
+        return Ok(ApiResponse<KaseResponse>.Success(kase));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateKaseRequest request)
+    {
+        var kase = await _kases.UpdateAsync(id, request.Title, request.Description);
+        if (kase is null)
+            return NotFound(ApiResponse<KaseResponse>.NotFound($"Kase with ID '{id}' was not found."));
+        return Ok(ApiResponse<KaseResponse>.Success(kase));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var deleted = await _kases.DeleteAsync(id);
+        if (!deleted)
+            return NotFound(ApiResponse<KaseResponse>.NotFound($"Kase with ID '{id}' was not found."));
+        return NoContent();
+    }
+}

--- a/src/KaseLog.Api/Data/IKaseRepository.cs
+++ b/src/KaseLog.Api/Data/IKaseRepository.cs
@@ -1,0 +1,12 @@
+using KaseLog.Api.Models;
+
+namespace KaseLog.Api.Data;
+
+public interface IKaseRepository
+{
+    Task<IEnumerable<KaseResponse>> GetAllAsync();
+    Task<KaseResponse?> GetByIdAsync(Guid id);
+    Task<KaseResponse> CreateAsync(string title, string? description);
+    Task<KaseResponse?> UpdateAsync(Guid id, string title, string? description);
+    Task<bool> DeleteAsync(Guid id);
+}

--- a/src/KaseLog.Api/Data/Sqlite/SqliteKaseRepository.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteKaseRepository.cs
@@ -1,0 +1,108 @@
+using Dapper;
+using KaseLog.Api.Models;
+
+namespace KaseLog.Api.Data.Sqlite;
+
+public sealed class SqliteKaseRepository : IKaseRepository
+{
+    private readonly IDbConnectionFactory _db;
+
+    public SqliteKaseRepository(IDbConnectionFactory db) => _db = db;
+
+    public async Task<IEnumerable<KaseResponse>> GetAllAsync()
+    {
+        using var conn = await _db.OpenAsync();
+        var rows = await conn.QueryAsync<KaseRow>("""
+            SELECT k.Id, k.Title, k.Description, k.CreatedAt, k.UpdatedAt,
+                   COUNT(l.Id) AS LogCount
+            FROM Kases k
+            LEFT JOIN Logs l ON l.KaseId = k.Id
+            GROUP BY k.Id
+            ORDER BY k.UpdatedAt DESC
+            """);
+        return rows.Select(Map);
+    }
+
+    public async Task<KaseResponse?> GetByIdAsync(Guid id)
+    {
+        using var conn = await _db.OpenAsync();
+        var row = await conn.QuerySingleOrDefaultAsync<KaseRow>("""
+            SELECT k.Id, k.Title, k.Description, k.CreatedAt, k.UpdatedAt,
+                   COUNT(l.Id) AS LogCount
+            FROM Kases k
+            LEFT JOIN Logs l ON l.KaseId = k.Id
+            WHERE k.Id = @Id
+            GROUP BY k.Id
+            """, new { Id = id.ToString() });
+        return row is null ? null : Map(row);
+    }
+
+    public async Task<KaseResponse> CreateAsync(string title, string? description)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var nowStr = now.ToString("O");
+
+        using var conn = await _db.OpenAsync();
+        await conn.ExecuteAsync("""
+            INSERT INTO Kases (Id, Title, Description, CreatedAt, UpdatedAt)
+            VALUES (@Id, @Title, @Description, @Now, @Now)
+            """,
+            new { Id = id.ToString(), Title = title, Description = description, Now = nowStr });
+
+        return new KaseResponse
+        {
+            Id = id,
+            Title = title,
+            Description = description,
+            LogCount = 0,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public async Task<KaseResponse?> UpdateAsync(Guid id, string title, string? description)
+    {
+        var nowStr = DateTime.UtcNow.ToString("O");
+
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync("""
+            UPDATE Kases SET Title = @Title, Description = @Description, UpdatedAt = @Now
+            WHERE Id = @Id
+            """,
+            new { Id = id.ToString(), Title = title, Description = description, Now = nowStr });
+
+        if (affected == 0) return null;
+
+        return await GetByIdAsync(id);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id)
+    {
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync(
+            "DELETE FROM Kases WHERE Id = @Id",
+            new { Id = id.ToString() });
+        return affected > 0;
+    }
+
+    private static KaseResponse Map(KaseRow row) => new()
+    {
+        Id = Guid.Parse(row.Id),
+        Title = row.Title,
+        Description = row.Description,
+        LogCount = (int)row.LogCount,
+        CreatedAt = DateTime.Parse(row.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+        UpdatedAt = DateTime.Parse(row.UpdatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+    };
+
+    private sealed class KaseRow
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public long LogCount { get; set; }
+        public string CreatedAt { get; set; } = string.Empty;
+        public string UpdatedAt { get; set; } = string.Empty;
+    }
+}

--- a/src/KaseLog.Api/Models/ApiResponse.cs
+++ b/src/KaseLog.Api/Models/ApiResponse.cs
@@ -1,0 +1,35 @@
+namespace KaseLog.Api.Models;
+
+public sealed class ApiResponse<T>
+{
+    public T? Data { get; init; }
+    public object? Error { get; init; }
+    public object? Meta { get; init; }
+
+    public static ApiResponse<T> Success(T data) => new() { Data = data };
+
+    public static ApiResponse<T> Failure(
+        string type,
+        string title,
+        int status,
+        string? detail = null,
+        object? errors = null)
+        => new()
+        {
+            Error = new
+            {
+                type,
+                title,
+                status,
+                detail,
+                errors,
+            },
+        };
+
+    public static ApiResponse<T> NotFound(string detail)
+        => Failure(
+            "https://tools.ietf.org/html/rfc7807",
+            "Not Found",
+            404,
+            detail);
+}

--- a/src/KaseLog.Api/Models/KaseResponse.cs
+++ b/src/KaseLog.Api/Models/KaseResponse.cs
@@ -1,0 +1,11 @@
+namespace KaseLog.Api.Models;
+
+public sealed class KaseResponse
+{
+    public Guid Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public int LogCount { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime UpdatedAt { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/CreateKaseRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/CreateKaseRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class CreateKaseRequest
+{
+    [Required]
+    [StringLength(200, MinimumLength = 1)]
+    public string Title { get; init; } = string.Empty;
+
+    [StringLength(1000)]
+    public string? Description { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/UpdateKaseRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/UpdateKaseRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class UpdateKaseRequest
+{
+    [Required]
+    [StringLength(200, MinimumLength = 1)]
+    public string Title { get; init; } = string.Empty;
+
+    [StringLength(1000)]
+    public string? Description { get; init; }
+}

--- a/src/KaseLog.Api/Program.cs
+++ b/src/KaseLog.Api/Program.cs
@@ -1,5 +1,6 @@
 using KaseLog.Api.Data;
 using KaseLog.Api.Data.Sqlite;
+using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,21 +10,51 @@ builder.WebHost.UseUrls($"http://*:{port}");
 // ── Database ─────────────────────────────────────────────────────────────────
 var dbProvider = Environment.GetEnvironmentVariable("KASELOG_DB_PROVIDER") ?? "sqlite";
 var dataPath   = Environment.GetEnvironmentVariable("KASELOG_DATA_PATH")   ?? "/data/kaselog.db";
-var connString = Environment.GetEnvironmentVariable("KASELOG_CONNECTION_STRING")
-                 ?? $"Data Source={dataPath};";
+var connStringEnv = Environment.GetEnvironmentVariable("KASELOG_CONNECTION_STRING");
+var connString = !string.IsNullOrEmpty(connStringEnv)
+                 ? connStringEnv
+                 : $"Data Source={dataPath};";
 
 if (dbProvider.Equals("sqlite", StringComparison.OrdinalIgnoreCase))
 {
     builder.Services.AddSingleton<IDbConnectionFactory>(
         new SqliteConnectionFactory(connString));
     builder.Services.AddSingleton<ISchemaInitializer, SqliteSchemaInitializer>();
+    builder.Services.AddScoped<IKaseRepository, SqliteKaseRepository>();
 }
 else
 {
     throw new InvalidOperationException($"Unsupported database provider: '{dbProvider}'.");
 }
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .ConfigureApiBehaviorOptions(options =>
+    {
+        options.InvalidModelStateResponseFactory = context =>
+        {
+            var errors = context.ModelState
+                .Where(x => x.Value?.Errors.Count > 0)
+                .ToDictionary(
+                    x => x.Key,
+                    x => x.Value!.Errors.Select(e => e.ErrorMessage).ToArray());
+
+            var response = new
+            {
+                data = (object?)null,
+                error = new
+                {
+                    type = "https://tools.ietf.org/html/rfc7807",
+                    title = "Validation failed",
+                    status = 400,
+                    detail = "One or more validation errors occurred.",
+                    errors,
+                },
+                meta = (object?)null,
+            };
+
+            return new BadRequestObjectResult(response);
+        };
+    });
 
 var app = builder.Build();
 

--- a/tests/KaseLog.Api.Tests/Controllers/KasesControllerTests.cs
+++ b/tests/KaseLog.Api.Tests/Controllers/KasesControllerTests.cs
@@ -1,0 +1,241 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Dapper;
+using KaseLog.Api.Data;
+using KaseLog.Api.Data.Sqlite;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace KaseLog.Api.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for GET/POST/PUT/DELETE /api/kases.
+/// Each test gets an isolated named in-memory SQLite database.
+/// </summary>
+public sealed class KasesControllerTests : IAsyncLifetime
+{
+    private readonly string _dbName;
+    private string _testConnString = null!;
+    private SqliteConnection _keepAlive = null!;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public KasesControllerTests()
+    {
+        _dbName = $"KasesTest_{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        _testConnString = $"Data Source={_dbName};Mode=Memory;Cache=Shared";
+
+        // Hold a connection open so SQLite keeps the in-memory DB alive.
+        _keepAlive = new SqliteConnection(_testConnString);
+        await _keepAlive.OpenAsync();
+
+        // Point the app's data path to a temp dir to avoid /data permission issues.
+        var tempDir = Path.Combine(Path.GetTempPath(), _dbName);
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH",
+            Path.Combine(tempDir, "kaselog.db"));
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    // Replace the production IDbConnectionFactory with the test one.
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IDbConnectionFactory));
+                    if (descriptor is not null) services.Remove(descriptor);
+
+                    services.AddSingleton<IDbConnectionFactory>(
+                        new SqliteConnectionFactory(_testConnString));
+                });
+            });
+
+        // Creating the client triggers app startup, which initializes the schema.
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH", null);
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _keepAlive.DisposeAsync();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private async Task InsertLogAsync(string kaseId)
+    {
+        await using var conn = new SqliteConnection(_testConnString);
+        await conn.OpenAsync();
+        await conn.ExecuteAsync("PRAGMA foreign_keys=ON;");
+        var now = DateTime.UtcNow.ToString("O");
+        await conn.ExecuteAsync(
+            "INSERT INTO Logs (Id, KaseId, Title, AutosaveEnabled, CreatedAt, UpdatedAt) " +
+            "VALUES (@Id, @KaseId, @Title, 1, @Now, @Now)",
+            new { Id = Guid.NewGuid().ToString(), KaseId = kaseId, Title = "Test Log", Now = now });
+    }
+
+    private async Task<JsonElement> PostKaseAsync(string title, string? description = null)
+    {
+        var body = new { title, description };
+        var response = await _client.PostAsJsonAsync("/api/kases", body);
+        response.EnsureSuccessStatusCode();
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        return root.GetProperty("data");
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetKases_EmptyDatabase_ReturnsEmptyList()
+    {
+        var response = await _client.GetAsync("/api/kases");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("data").ValueKind);
+        Assert.Equal(0, root.GetProperty("data").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task PostKase_ValidRequest_CreatesKaseWithAllFields()
+    {
+        var response = await _client.PostAsJsonAsync("/api/kases",
+            new { title = "My Kase", description = "A description" });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("error").ValueKind);
+
+        var data = root.GetProperty("data");
+        Assert.NotEqual(Guid.Empty, Guid.Parse(data.GetProperty("id").GetString()!));
+        Assert.Equal("My Kase", data.GetProperty("title").GetString());
+        Assert.Equal("A description", data.GetProperty("description").GetString());
+        Assert.Equal(0, data.GetProperty("logCount").GetInt32());
+        Assert.NotEmpty(data.GetProperty("createdAt").GetString()!);
+        Assert.NotEmpty(data.GetProperty("updatedAt").GetString()!);
+    }
+
+    [Fact]
+    public async Task PostKase_EmptyTitle_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync("/api/kases",
+            new { title = "" });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostKase_TitleOver200Chars_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync("/api/kases",
+            new { title = new string('A', 201) });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetKaseById_UnknownId_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/kases/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetKaseById_ExistingKase_ReturnsCorrectKaseWithLogCount()
+    {
+        var data = await PostKaseAsync("Test Kase");
+        var id = data.GetProperty("id").GetString()!;
+
+        var response = await _client.GetAsync($"/api/kases/{id}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        var fetched = root.GetProperty("data");
+
+        Assert.Equal(id, fetched.GetProperty("id").GetString());
+        Assert.Equal("Test Kase", fetched.GetProperty("title").GetString());
+        Assert.Equal(0, fetched.GetProperty("logCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task PutKase_ValidRequest_UpdatesTitleAndUpdatedAt()
+    {
+        var created = await PostKaseAsync("Original Title");
+        var id = created.GetProperty("id").GetString()!;
+        var originalUpdatedAt = created.GetProperty("updatedAt").GetString()!;
+
+        // Small delay to ensure UpdatedAt advances
+        await Task.Delay(10);
+
+        var response = await _client.PutAsJsonAsync($"/api/kases/{id}",
+            new { title = "Updated Title" });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        var data = root.GetProperty("data");
+
+        Assert.Equal("Updated Title", data.GetProperty("title").GetString());
+
+        var newUpdatedAt = data.GetProperty("updatedAt").GetString()!;
+        Assert.True(
+            DateTime.Parse(newUpdatedAt) >= DateTime.Parse(originalUpdatedAt),
+            "UpdatedAt should be >= original after update");
+    }
+
+    [Fact]
+    public async Task PutKase_UnknownId_Returns404()
+    {
+        var response = await _client.PutAsJsonAsync($"/api/kases/{Guid.NewGuid()}",
+            new { title = "New Title" });
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteKase_ExistingKase_Returns204AndRemovesKase()
+    {
+        var data = await PostKaseAsync("To Delete");
+        var id = data.GetProperty("id").GetString()!;
+
+        var deleteResponse = await _client.DeleteAsync($"/api/kases/{id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var getResponse = await _client.GetAsync($"/api/kases/{id}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteKase_UnknownId_Returns404()
+    {
+        var response = await _client.DeleteAsync($"/api/kases/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetKaseById_AfterLogsAdded_LogCountIsAccurate()
+    {
+        var data = await PostKaseAsync("Kase With Logs");
+        var id = data.GetProperty("id").GetString()!;
+
+        await InsertLogAsync(id);
+        await InsertLogAsync(id);
+
+        var response = await _client.GetAsync($"/api/kases/{id}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(2, root.GetProperty("data").GetProperty("logCount").GetInt32());
+    }
+}

--- a/tests/KaseLog.Api.Tests/Data/SchemaTests.cs
+++ b/tests/KaseLog.Api.Tests/Data/SchemaTests.cs
@@ -1,7 +1,9 @@
+using System.Data;
 using Dapper;
 using KaseLog.Api.Data;
 using KaseLog.Api.Data.Sqlite;
 using Microsoft.Data.Sqlite;
+using Xunit;
 
 namespace KaseLog.Api.Tests.Data;
 

--- a/tests/KaseLog.Api.Tests/PlaceholderTest.cs
+++ b/tests/KaseLog.Api.Tests/PlaceholderTest.cs
@@ -1,3 +1,5 @@
+using Xunit;
+
 namespace KaseLog.Api.Tests;
 
 public class PlaceholderTest


### PR DESCRIPTION
## Summary

- Implements all 5 Kases endpoints (`GET /api/kases`, `POST`, `GET /{id}`, `PUT /{id}`, `DELETE /{id}`)
- Each response uses the `{ data, error, meta }` envelope; errors follow RFC 7807 Problem Details format
- `LogCount` is always accurate via `LEFT JOIN + COUNT + GROUP BY` in the repository
- Fixes a pre-existing bug where `KASELOG_CONNECTION_STRING=""` (empty string set in Docker env) bypassed the `??` fallback, causing the schema initializer and repository to use separate ephemeral in-memory SQLite databases — resulting in "no such table" errors in the container
- Fixes missing `using Xunit;` / `using System.Data;` in existing test files (they had never been compiled in Docker)

## Test plan

- [ ] All 20 xUnit tests pass: `docker run --rm -v <path>:/repo mcr.microsoft.com/dotnet/sdk:9.0 bash -c "cd /repo && dotnet test tests/KaseLog.Api.Tests/KaseLog.Api.Tests.csproj"`
- [ ] `docker compose up --build` succeeds with no errors
- [ ] `GET /api/kases` returns `{"data":[],"error":null,"meta":null}` with HTTP 200
- [ ] `GET /health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)