### PR TITLE
feat: Logs and LogVersions API with xUnit integration tests

### DIFF
--- a/src/KaseLog.Api/Controllers/KaseLogsController.cs
+++ b/src/KaseLog.Api/Controllers/KaseLogsController.cs
@@ -1,0 +1,42 @@
+using KaseLog.Api.Data;
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KaseLog.Api.Controllers;
+
+[ApiController]
+[Route("api/kases/{kaseId:guid}/logs")]
+public sealed class KaseLogsController : ControllerBase
+{
+    private readonly ILogRepository _logs;
+    private readonly IKaseRepository _kases;
+
+    public KaseLogsController(ILogRepository logs, IKaseRepository kases)
+    {
+        _logs = logs;
+        _kases = kases;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetByKase(Guid kaseId)
+    {
+        var kase = await _kases.GetByIdAsync(kaseId);
+        if (kase is null)
+            return NotFound(ApiResponse<IEnumerable<LogResponse>>.NotFound($"Kase with ID '{kaseId}' was not found."));
+
+        var logs = await _logs.GetByKaseIdAsync(kaseId);
+        return Ok(ApiResponse<IEnumerable<LogResponse>>.Success(logs));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(Guid kaseId, [FromBody] CreateLogRequest request)
+    {
+        var log = await _logs.CreateAsync(kaseId, request.Title, request.Description, request.AutosaveEnabled);
+        if (log is null)
+            return NotFound(ApiResponse<LogResponse>.NotFound($"Kase with ID '{kaseId}' was not found."));
+
+        return CreatedAtAction("GetById", "Logs", new { id = log.Id },
+            ApiResponse<LogResponse>.Success(log));
+    }
+}

--- a/src/KaseLog.Api/Controllers/LogsController.cs
+++ b/src/KaseLog.Api/Controllers/LogsController.cs
@@ -1,0 +1,86 @@
+using KaseLog.Api.Data;
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KaseLog.Api.Controllers;
+
+[ApiController]
+[Route("api/logs")]
+public sealed class LogsController : ControllerBase
+{
+    private readonly ILogRepository _logs;
+
+    public LogsController(ILogRepository logs) => _logs = logs;
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var log = await _logs.GetByIdAsync(id);
+        if (log is null)
+            return NotFound(ApiResponse<LogResponse>.NotFound($"Log with ID '{id}' was not found."));
+        return Ok(ApiResponse<LogResponse>.Success(log));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateLogRequest request)
+    {
+        var log = await _logs.UpdateAsync(id, request.Title, request.Description, request.AutosaveEnabled);
+        if (log is null)
+            return NotFound(ApiResponse<LogResponse>.NotFound($"Log with ID '{id}' was not found."));
+        return Ok(ApiResponse<LogResponse>.Success(log));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var deleted = await _logs.DeleteAsync(id);
+        if (!deleted)
+            return NotFound(ApiResponse<LogResponse>.NotFound($"Log with ID '{id}' was not found."));
+        return NoContent();
+    }
+
+    // ── Log Versions ──────────────────────────────────────────────────────────
+
+    [HttpGet("{logId:guid}/versions")]
+    public async Task<IActionResult> GetVersions(Guid logId)
+    {
+        var log = await _logs.GetByIdAsync(logId);
+        if (log is null)
+            return NotFound(ApiResponse<IEnumerable<LogVersionResponse>>.NotFound($"Log with ID '{logId}' was not found."));
+
+        var versions = await _logs.GetVersionsAsync(logId);
+        return Ok(ApiResponse<IEnumerable<LogVersionResponse>>.Success(versions));
+    }
+
+    [HttpPost("{logId:guid}/versions")]
+    public async Task<IActionResult> AddVersion(Guid logId, [FromBody] CreateVersionRequest request)
+    {
+        var version = await _logs.AddVersionAsync(logId, request.Content, request.Label, request.IsAutosave);
+        if (version is null)
+            return NotFound(ApiResponse<LogVersionResponse>.NotFound($"Log with ID '{logId}' was not found."));
+
+        return CreatedAtAction(nameof(GetVersionById), new { logId, versionId = version.Id },
+            ApiResponse<LogVersionResponse>.Success(version));
+    }
+
+    [HttpGet("{logId:guid}/versions/{versionId:guid}")]
+    public async Task<IActionResult> GetVersionById(Guid logId, Guid versionId)
+    {
+        var version = await _logs.GetVersionByIdAsync(logId, versionId);
+        if (version is null)
+            return NotFound(ApiResponse<LogVersionResponse>.NotFound(
+                $"Version with ID '{versionId}' was not found for Log '{logId}'."));
+        return Ok(ApiResponse<LogVersionResponse>.Success(version));
+    }
+
+    [HttpPost("{logId:guid}/versions/{versionId:guid}/restore")]
+    public async Task<IActionResult> RestoreVersion(Guid logId, Guid versionId)
+    {
+        var version = await _logs.RestoreVersionAsync(logId, versionId);
+        if (version is null)
+            return NotFound(ApiResponse<LogVersionResponse>.NotFound(
+                $"Version with ID '{versionId}' was not found for Log '{logId}'."));
+        return Ok(ApiResponse<LogVersionResponse>.Success(version));
+    }
+}

--- a/src/KaseLog.Api/Data/ILogRepository.cs
+++ b/src/KaseLog.Api/Data/ILogRepository.cs
@@ -1,0 +1,16 @@
+using KaseLog.Api.Models;
+
+namespace KaseLog.Api.Data;
+
+public interface ILogRepository
+{
+    Task<IEnumerable<LogResponse>> GetByKaseIdAsync(Guid kaseId);
+    Task<LogResponse?> GetByIdAsync(Guid id);
+    Task<LogResponse?> CreateAsync(Guid kaseId, string title, string? description, bool autosaveEnabled);
+    Task<LogResponse?> UpdateAsync(Guid id, string title, string? description, bool autosaveEnabled);
+    Task<bool> DeleteAsync(Guid id);
+    Task<IEnumerable<LogVersionResponse>> GetVersionsAsync(Guid logId);
+    Task<LogVersionResponse?> GetVersionByIdAsync(Guid logId, Guid versionId);
+    Task<LogVersionResponse?> AddVersionAsync(Guid logId, string content, string? label, bool isAutosave);
+    Task<LogVersionResponse?> RestoreVersionAsync(Guid logId, Guid versionId);
+}

--- a/src/KaseLog.Api/Data/Sqlite/SqliteLogRepository.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteLogRepository.cs
@@ -1,0 +1,241 @@
+using Dapper;
+using KaseLog.Api.Models;
+
+namespace KaseLog.Api.Data.Sqlite;
+
+public sealed class SqliteLogRepository : ILogRepository
+{
+    private readonly IDbConnectionFactory _db;
+
+    public SqliteLogRepository(IDbConnectionFactory db) => _db = db;
+
+    public async Task<IEnumerable<LogResponse>> GetByKaseIdAsync(Guid kaseId)
+    {
+        using var conn = await _db.OpenAsync();
+        var rows = await conn.QueryAsync<LogRow>("""
+            SELECT l.Id, l.KaseId, l.Title, l.Description, l.AutosaveEnabled, l.CreatedAt, l.UpdatedAt,
+                   COALESCE((SELECT Content FROM LogVersions WHERE LogId = l.Id ORDER BY CreatedAt DESC LIMIT 1), '') AS Content,
+                   (SELECT COUNT(*) FROM LogVersions WHERE LogId = l.Id) AS VersionCount
+            FROM Logs l
+            WHERE l.KaseId = @KaseId
+            ORDER BY l.UpdatedAt DESC
+            """, new { KaseId = kaseId.ToString() });
+        return rows.Select(Map);
+    }
+
+    public async Task<LogResponse?> GetByIdAsync(Guid id)
+    {
+        using var conn = await _db.OpenAsync();
+        var row = await conn.QuerySingleOrDefaultAsync<LogRow>("""
+            SELECT l.Id, l.KaseId, l.Title, l.Description, l.AutosaveEnabled, l.CreatedAt, l.UpdatedAt,
+                   COALESCE((SELECT Content FROM LogVersions WHERE LogId = l.Id ORDER BY CreatedAt DESC LIMIT 1), '') AS Content,
+                   (SELECT COUNT(*) FROM LogVersions WHERE LogId = l.Id) AS VersionCount
+            FROM Logs l
+            WHERE l.Id = @Id
+            """, new { Id = id.ToString() });
+        return row is null ? null : Map(row);
+    }
+
+    public async Task<LogResponse?> CreateAsync(Guid kaseId, string title, string? description, bool autosaveEnabled)
+    {
+        var logId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var nowStr = now.ToString("O");
+
+        using var conn = await _db.OpenAsync();
+
+        var kaseExists = await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM Kases WHERE Id = @KaseId",
+            new { KaseId = kaseId.ToString() });
+
+        if (kaseExists == 0) return null;
+
+        using var tx = conn.BeginTransaction();
+        try
+        {
+            await conn.ExecuteAsync("""
+                INSERT INTO Logs (Id, KaseId, Title, Description, AutosaveEnabled, CreatedAt, UpdatedAt)
+                VALUES (@Id, @KaseId, @Title, @Description, @AutosaveEnabled, @Now, @Now)
+                """,
+                new
+                {
+                    Id = logId.ToString(),
+                    KaseId = kaseId.ToString(),
+                    Title = title,
+                    Description = description,
+                    AutosaveEnabled = autosaveEnabled ? 1 : 0,
+                    Now = nowStr,
+                }, tx);
+
+            await conn.ExecuteAsync("""
+                INSERT INTO LogVersions (Id, LogId, Content, Label, IsAutosave, CreatedAt)
+                VALUES (@Id, @LogId, '', NULL, 1, @Now)
+                """,
+                new { Id = versionId.ToString(), LogId = logId.ToString(), Now = nowStr }, tx);
+
+            tx.Commit();
+        }
+        catch
+        {
+            tx.Rollback();
+            throw;
+        }
+
+        return await GetByIdAsync(logId);
+    }
+
+    public async Task<LogResponse?> UpdateAsync(Guid id, string title, string? description, bool autosaveEnabled)
+    {
+        var nowStr = DateTime.UtcNow.ToString("O");
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync("""
+            UPDATE Logs SET Title = @Title, Description = @Description, AutosaveEnabled = @AutosaveEnabled, UpdatedAt = @Now
+            WHERE Id = @Id
+            """,
+            new { Id = id.ToString(), Title = title, Description = description, AutosaveEnabled = autosaveEnabled ? 1 : 0, Now = nowStr });
+
+        if (affected == 0) return null;
+        return await GetByIdAsync(id);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id)
+    {
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync(
+            "DELETE FROM Logs WHERE Id = @Id",
+            new { Id = id.ToString() });
+        return affected > 0;
+    }
+
+    public async Task<IEnumerable<LogVersionResponse>> GetVersionsAsync(Guid logId)
+    {
+        using var conn = await _db.OpenAsync();
+        var rows = await conn.QueryAsync<VersionRow>("""
+            SELECT Id, LogId, Content, Label, IsAutosave, CreatedAt
+            FROM LogVersions
+            WHERE LogId = @LogId
+            ORDER BY CreatedAt DESC
+            """, new { LogId = logId.ToString() });
+        return rows.Select(MapVersion);
+    }
+
+    public async Task<LogVersionResponse?> GetVersionByIdAsync(Guid logId, Guid versionId)
+    {
+        using var conn = await _db.OpenAsync();
+        var row = await conn.QuerySingleOrDefaultAsync<VersionRow>("""
+            SELECT Id, LogId, Content, Label, IsAutosave, CreatedAt
+            FROM LogVersions
+            WHERE LogId = @LogId AND Id = @Id
+            """, new { LogId = logId.ToString(), Id = versionId.ToString() });
+        return row is null ? null : MapVersion(row);
+    }
+
+    public async Task<LogVersionResponse?> AddVersionAsync(Guid logId, string content, string? label, bool isAutosave)
+    {
+        using var conn = await _db.OpenAsync();
+
+        var logExists = await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM Logs WHERE Id = @LogId",
+            new { LogId = logId.ToString() });
+
+        if (logExists == 0) return null;
+
+        var versionId = Guid.NewGuid();
+        var nowStr = DateTime.UtcNow.ToString("O");
+
+        await conn.ExecuteAsync("""
+            INSERT INTO LogVersions (Id, LogId, Content, Label, IsAutosave, CreatedAt)
+            VALUES (@Id, @LogId, @Content, @Label, @IsAutosave, @Now)
+            """,
+            new
+            {
+                Id = versionId.ToString(),
+                LogId = logId.ToString(),
+                Content = content,
+                Label = label,
+                IsAutosave = isAutosave ? 1 : 0,
+                Now = nowStr,
+            });
+
+        await conn.ExecuteAsync(
+            "UPDATE Logs SET UpdatedAt = @Now WHERE Id = @LogId",
+            new { LogId = logId.ToString(), Now = nowStr });
+
+        return await GetVersionByIdAsync(logId, versionId);
+    }
+
+    public async Task<LogVersionResponse?> RestoreVersionAsync(Guid logId, Guid versionId)
+    {
+        using var conn = await _db.OpenAsync();
+
+        var sourceVersion = await conn.QuerySingleOrDefaultAsync<VersionRow>("""
+            SELECT Id, LogId, Content, Label, IsAutosave, CreatedAt
+            FROM LogVersions
+            WHERE LogId = @LogId AND Id = @Id
+            """, new { LogId = logId.ToString(), Id = versionId.ToString() });
+
+        if (sourceVersion is null) return null;
+
+        var newVersionId = Guid.NewGuid();
+        var nowStr = DateTime.UtcNow.ToString("O");
+
+        await conn.ExecuteAsync("""
+            INSERT INTO LogVersions (Id, LogId, Content, Label, IsAutosave, CreatedAt)
+            VALUES (@Id, @LogId, @Content, NULL, 0, @Now)
+            """,
+            new { Id = newVersionId.ToString(), LogId = logId.ToString(), Content = sourceVersion.Content, Now = nowStr });
+
+        await conn.ExecuteAsync(
+            "UPDATE Logs SET UpdatedAt = @Now WHERE Id = @LogId",
+            new { LogId = logId.ToString(), Now = nowStr });
+
+        return await GetVersionByIdAsync(logId, newVersionId);
+    }
+
+    private static LogResponse Map(LogRow row) => new()
+    {
+        Id = Guid.Parse(row.Id),
+        KaseId = Guid.Parse(row.KaseId),
+        Title = row.Title,
+        Description = row.Description,
+        AutosaveEnabled = row.AutosaveEnabled != 0,
+        Content = row.Content,
+        VersionCount = (int)row.VersionCount,
+        CreatedAt = DateTime.Parse(row.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+        UpdatedAt = DateTime.Parse(row.UpdatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+    };
+
+    private static LogVersionResponse MapVersion(VersionRow row) => new()
+    {
+        Id = Guid.Parse(row.Id),
+        LogId = Guid.Parse(row.LogId),
+        Content = row.Content,
+        Label = row.Label,
+        IsAutosave = row.IsAutosave != 0,
+        CreatedAt = DateTime.Parse(row.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+    };
+
+    private sealed class LogRow
+    {
+        public string Id { get; set; } = string.Empty;
+        public string KaseId { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public int AutosaveEnabled { get; set; }
+        public string Content { get; set; } = string.Empty;
+        public long VersionCount { get; set; }
+        public string CreatedAt { get; set; } = string.Empty;
+        public string UpdatedAt { get; set; } = string.Empty;
+    }
+
+    private sealed class VersionRow
+    {
+        public string Id { get; set; } = string.Empty;
+        public string LogId { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public string? Label { get; set; }
+        public int IsAutosave { get; set; }
+        public string CreatedAt { get; set; } = string.Empty;
+    }
+}

--- a/src/KaseLog.Api/Data/Sqlite/SqliteSchemaInitializer.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteSchemaInitializer.cs
@@ -134,5 +134,16 @@ public sealed class SqliteSchemaInitializer : ISchemaInitializer
           LIMIT 1;
         END
         """,
+
+        // LOG DELETE: SQLite cascade deletes (LogVersions removed via FK) do not
+        // fire row-level triggers on the child table. This trigger ensures the FTS
+        // entry is always removed when a Log itself is deleted.
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_log_delete
+        AFTER DELETE ON Logs
+        BEGIN
+          DELETE FROM kaselog_search WHERE log_id = OLD.Id;
+        END
+        """,
     ];
 }

--- a/src/KaseLog.Api/Models/LogResponse.cs
+++ b/src/KaseLog.Api/Models/LogResponse.cs
@@ -1,0 +1,14 @@
+namespace KaseLog.Api.Models;
+
+public sealed class LogResponse
+{
+    public Guid Id { get; init; }
+    public Guid KaseId { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public bool AutosaveEnabled { get; init; }
+    public string Content { get; init; } = string.Empty;
+    public int VersionCount { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime UpdatedAt { get; init; }
+}

--- a/src/KaseLog.Api/Models/LogVersionResponse.cs
+++ b/src/KaseLog.Api/Models/LogVersionResponse.cs
@@ -1,0 +1,11 @@
+namespace KaseLog.Api.Models;
+
+public sealed class LogVersionResponse
+{
+    public Guid Id { get; init; }
+    public Guid LogId { get; init; }
+    public string Content { get; init; } = string.Empty;
+    public string? Label { get; init; }
+    public bool IsAutosave { get; init; }
+    public DateTime CreatedAt { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/CreateLogRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/CreateLogRequest.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class CreateLogRequest
+{
+    [Required]
+    [StringLength(200, MinimumLength = 1)]
+    public string Title { get; init; } = string.Empty;
+
+    [StringLength(500)]
+    public string? Description { get; init; }
+
+    public bool AutosaveEnabled { get; init; } = true;
+}

--- a/src/KaseLog.Api/Models/Requests/CreateVersionRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/CreateVersionRequest.cs
@@ -1,0 +1,8 @@
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class CreateVersionRequest
+{
+    public string Content { get; init; } = string.Empty;
+    public string? Label { get; init; }
+    public bool IsAutosave { get; init; } = true;
+}

--- a/src/KaseLog.Api/Models/Requests/UpdateLogRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/UpdateLogRequest.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class UpdateLogRequest
+{
+    [Required]
+    [StringLength(200, MinimumLength = 1)]
+    public string Title { get; init; } = string.Empty;
+
+    [StringLength(500)]
+    public string? Description { get; init; }
+
+    public bool AutosaveEnabled { get; init; } = true;
+}

--- a/src/KaseLog.Api/Program.cs
+++ b/src/KaseLog.Api/Program.cs
@@ -21,6 +21,7 @@ if (dbProvider.Equals("sqlite", StringComparison.OrdinalIgnoreCase))
         new SqliteConnectionFactory(connString));
     builder.Services.AddSingleton<ISchemaInitializer, SqliteSchemaInitializer>();
     builder.Services.AddScoped<IKaseRepository, SqliteKaseRepository>();
+    builder.Services.AddScoped<ILogRepository, SqliteLogRepository>();
 }
 else
 {

--- a/tests/KaseLog.Api.Tests/Controllers/LogsControllerTests.cs
+++ b/tests/KaseLog.Api.Tests/Controllers/LogsControllerTests.cs
@@ -1,0 +1,401 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Dapper;
+using KaseLog.Api.Data;
+using KaseLog.Api.Data.Sqlite;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace KaseLog.Api.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for Logs and LogVersions endpoints.
+/// Each test gets an isolated named in-memory SQLite database.
+/// </summary>
+public sealed class LogsControllerTests : IAsyncLifetime
+{
+    private readonly string _dbName;
+    private string _testConnString = null!;
+    private SqliteConnection _keepAlive = null!;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public LogsControllerTests()
+    {
+        _dbName = $"LogsTest_{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        _testConnString = $"Data Source={_dbName};Mode=Memory;Cache=Shared";
+
+        _keepAlive = new SqliteConnection(_testConnString);
+        await _keepAlive.OpenAsync();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), _dbName);
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH",
+            Path.Combine(tempDir, "kaselog.db"));
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IDbConnectionFactory));
+                    if (descriptor is not null) services.Remove(descriptor);
+
+                    services.AddSingleton<IDbConnectionFactory>(
+                        new SqliteConnectionFactory(_testConnString));
+                });
+            });
+
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH", null);
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _keepAlive.DisposeAsync();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<JsonElement> PostKaseAsync(string title = "Test Kase")
+    {
+        var response = await _client.PostAsJsonAsync("/api/kases", new { title });
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+    }
+
+    private async Task<JsonElement> PostLogAsync(string kaseId, string title = "Test Log", string? description = null)
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/kases/{kaseId}/logs",
+            new { title, description });
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+    }
+
+    private async Task<JsonElement> PostVersionAsync(string logId, string content, string? label = null, bool isAutosave = true)
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/logs/{logId}/versions",
+            new { content, label, isAutosave });
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+    }
+
+    private async Task<SqliteConnection> OpenTestConnectionAsync()
+    {
+        var conn = new SqliteConnection(_testConnString);
+        await conn.OpenAsync();
+        await conn.ExecuteAsync("PRAGMA foreign_keys=ON;");
+        return conn;
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostLog_CreatesInitialEmptyLogVersion()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+
+        var log = await PostLogAsync(kaseId, "My Log");
+        var logId = log.GetProperty("id").GetString()!;
+
+        // VersionCount should be 1
+        Assert.Equal(1, log.GetProperty("versionCount").GetInt32());
+
+        // Verify the initial version exists in the DB with empty content
+        await using var conn = await OpenTestConnectionAsync();
+        var count = await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM LogVersions WHERE LogId = @LogId",
+            new { LogId = logId });
+        Assert.Equal(1, count);
+
+        var content = await conn.ExecuteScalarAsync<string>(
+            "SELECT Content FROM LogVersions WHERE LogId = @LogId",
+            new { LogId = logId });
+        Assert.Equal("", content);
+    }
+
+    [Fact]
+    public async Task GetLogById_ReturnsContentFromMostRecentVersion()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId);
+        var logId = log.GetProperty("id").GetString()!;
+
+        // Add a version with specific content
+        await PostVersionAsync(logId, "Version 2 content");
+        await PostVersionAsync(logId, "Version 3 content — most recent");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        var data = root.GetProperty("data");
+
+        Assert.Equal("Version 3 content — most recent", data.GetProperty("content").GetString());
+        Assert.Equal(3, data.GetProperty("versionCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task PostVersion_IncrementsVersionCount()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId);
+        var logId = log.GetProperty("id").GetString()!;
+
+        Assert.Equal(1, log.GetProperty("versionCount").GetInt32());
+
+        await PostVersionAsync(logId, "New content");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}");
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+
+        Assert.Equal(2, root.GetProperty("data").GetProperty("versionCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task PostVersion_NamedCheckpoint_IsAutosaveFalseAndLabelSet()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId);
+        var logId = log.GetProperty("id").GetString()!;
+
+        var version = await PostVersionAsync(logId, "Checkpoint content", label: "Release v1.0", isAutosave: false);
+
+        Assert.False(version.GetProperty("isAutosave").GetBoolean());
+        Assert.Equal("Release v1.0", version.GetProperty("label").GetString());
+    }
+
+    [Fact]
+    public async Task PostVersion_AutosaveVersion_IsAutosaveTrueAndLabelNull()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId);
+        var logId = log.GetProperty("id").GetString()!;
+
+        var version = await PostVersionAsync(logId, "Autosaved content", label: null, isAutosave: true);
+
+        Assert.True(version.GetProperty("isAutosave").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, version.GetProperty("label").ValueKind);
+    }
+
+    [Fact]
+    public async Task RestoreVersion_CreatesNewVersionAndLeavesHistoryUnchanged()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId);
+        var logId = log.GetProperty("id").GetString()!;
+
+        var v2 = await PostVersionAsync(logId, "Version 2 content");
+        var v2Id = v2.GetProperty("id").GetString()!;
+
+        var v3 = await PostVersionAsync(logId, "Version 3 content");
+        var v3Id = v3.GetProperty("id").GetString()!;
+
+        // Restore v2
+        var restoreResponse = await _client.PostAsync(
+            $"/api/logs/{logId}/versions/{v2Id}/restore", null);
+        Assert.Equal(HttpStatusCode.OK, restoreResponse.StatusCode);
+
+        var restored = JsonDocument.Parse(await restoreResponse.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+
+        // Restored version has v2 content
+        Assert.Equal("Version 2 content", restored.GetProperty("content").GetString());
+        // Restored version is a new entry (different ID)
+        Assert.NotEqual(v2Id, restored.GetProperty("id").GetString());
+
+        // History now has 4 versions (initial empty + v2 + v3 + restored)
+        var versionsResponse = await _client.GetAsync($"/api/logs/{logId}/versions");
+        var versions = JsonDocument.Parse(await versionsResponse.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+        Assert.Equal(4, versions.GetArrayLength());
+
+        // v2 and v3 still exist unchanged
+        var allIds = versions.EnumerateArray().Select(v => v.GetProperty("id").GetString()).ToList();
+        Assert.Contains(v2Id, allIds);
+        Assert.Contains(v3Id, allIds);
+    }
+
+    [Fact]
+    public async Task DeleteLog_CascadesToAllLogVersions()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId);
+        var logId = log.GetProperty("id").GetString()!;
+
+        await PostVersionAsync(logId, "Content A");
+        await PostVersionAsync(logId, "Content B");
+
+        var deleteResponse = await _client.DeleteAsync($"/api/logs/{logId}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        await using var conn = await OpenTestConnectionAsync();
+        var versionCount = await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM LogVersions WHERE LogId = @LogId",
+            new { LogId = logId });
+        Assert.Equal(0, versionCount);
+    }
+
+    [Fact]
+    public async Task PostVersion_UpdatesFts5Index()
+    {
+        var kase = await PostKaseAsync("Searchable Kase");
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId, "Searchable Log");
+        var logId = log.GetProperty("id").GetString()!;
+
+        await PostVersionAsync(logId, "uniqueterm_abc123 content here");
+
+        await using var conn = await OpenTestConnectionAsync();
+        var ftsCount = await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM kaselog_search WHERE kaselog_search MATCH 'uniqueterm_abc123'");
+        Assert.Equal(1, ftsCount);
+    }
+
+    [Fact]
+    public async Task DeleteLog_RemovesFts5Entry()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId);
+        var logId = log.GetProperty("id").GetString()!;
+
+        await PostVersionAsync(logId, "some content");
+
+        // Verify FTS entry exists before delete
+        await using var conn = await OpenTestConnectionAsync();
+        var beforeCount = await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM kaselog_search WHERE log_id = @LogId",
+            new { LogId = logId });
+        Assert.Equal(1, beforeCount);
+
+        await _client.DeleteAsync($"/api/logs/{logId}");
+
+        var afterCount = await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM kaselog_search WHERE log_id = @LogId",
+            new { LogId = logId });
+        Assert.Equal(0, afterCount);
+    }
+
+    [Fact]
+    public async Task GetLogById_UnknownId_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/logs/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("data").ValueKind);
+        Assert.NotEqual(JsonValueKind.Null, root.GetProperty("error").ValueKind);
+    }
+
+    [Fact]
+    public async Task PostLog_EmptyTitle_Returns400()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+
+        var response = await _client.PostAsJsonAsync($"/api/kases/{kaseId}/logs", new { title = "" });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostLog_TitleOver200Chars_Returns400()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+
+        var response = await _client.PostAsJsonAsync($"/api/kases/{kaseId}/logs",
+            new { title = new string('A', 201) });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostLog_UnknownKaseId_Returns404()
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/kases/{Guid.NewGuid()}/logs",
+            new { title = "Test" });
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLogsByKase_ReturnsLogsInReverseChronologicalOrder()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+
+        await PostLogAsync(kaseId, "Log A");
+        await Task.Delay(10);
+        await PostLogAsync(kaseId, "Log B");
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/logs");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var data = JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+        Assert.Equal(2, data.GetArrayLength());
+        // Most recent first
+        Assert.Equal("Log B", data[0].GetProperty("title").GetString());
+        Assert.Equal("Log A", data[1].GetProperty("title").GetString());
+    }
+
+    [Fact]
+    public async Task DeleteLog_UnknownId_Returns404()
+    {
+        var response = await _client.DeleteAsync($"/api/logs/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PutLog_UpdatesTitleAndDescription()
+    {
+        var kase = await PostKaseAsync();
+        var kaseId = kase.GetProperty("id").GetString()!;
+        var log = await PostLogAsync(kaseId, "Original Title");
+        var logId = log.GetProperty("id").GetString()!;
+
+        var response = await _client.PutAsJsonAsync($"/api/logs/{logId}",
+            new { title = "Updated Title", description = "New desc", autosaveEnabled = true });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var data = JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+        Assert.Equal("Updated Title", data.GetProperty("title").GetString());
+        Assert.Equal("New desc", data.GetProperty("description").GetString());
+    }
+
+    [Fact]
+    public async Task PutLog_UnknownId_Returns404()
+    {
+        var response = await _client.PutAsJsonAsync($"/api/logs/{Guid.NewGuid()}",
+            new { title = "Title", autosaveEnabled = true });
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary

- Full CRUD for Logs: `GET/POST /api/kases/{kaseId}/logs`, `GET/PUT/DELETE /api/logs/{id}`
- Full LogVersions API: list, create, get by ID, restore
- `POST /api/kases/{kaseId}/logs` creates the Log and an initial empty LogVersion in a single atomic transaction
- `GET /api/logs/{id}` returns metadata plus content from the most recent LogVersion
- Restore creates a new LogVersion — history is never mutated
- Added `fts_log_delete` trigger so the FTS5 index is cleaned up when a Log is deleted (SQLite cascade deletes do not fire row-level triggers on child tables)
- Registered `ILogRepository` / `SqliteLogRepository` in Program.cs DI

## Test plan

- [ ] All 37 xUnit tests pass (`dotnet test tests/KaseLog.Api.Tests`)
- [ ] `docker compose up --build` succeeds with no errors
- [ ] Creating a Log creates an initial empty LogVersion in the same transaction
- [ ] GET /api/logs/{id} returns content from most recent LogVersion
- [ ] POST /api/logs/{logId}/versions increments version count
- [ ] Named checkpoint: IsAutosave=false, Label set correctly
- [ ] Autosave version: IsAutosave=true, Label null
- [ ] Restore creates new version, existing history unchanged
- [ ] Deleting a Log cascades to all LogVersions
- [ ] FTS5 index updated after LogVersion created
- [ ] FTS5 index entry removed after Log deleted
- [ ] GET /api/logs/{id} returns 404 for unknown ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)