### PR TITLE
feat: React frontend shell with routing and typed API client

### DIFF
--- a/src/kaselog-ui/postcss.config.js
+++ b/src/kaselog-ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/kaselog-ui/src/App.tsx
+++ b/src/kaselog-ui/src/App.tsx
@@ -1,8 +1,21 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import Shell from './components/Shell'
+import KaseListPage from './pages/KaseListPage'
+import KaseViewPage from './pages/KaseViewPage'
+import LogViewPage from './pages/LogViewPage'
+import SearchPage from './pages/SearchPage'
+
 export default function App() {
   return (
-    <div style={{ fontFamily: 'sans-serif', padding: '2rem' }}>
-      <h1>KaseLog</h1>
-      <p>Project structure initialized.</p>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route element={<Shell />}>
+          <Route index element={<KaseListPage />} />
+          <Route path="kases/:id" element={<KaseViewPage />} />
+          <Route path="logs/:id" element={<LogViewPage />} />
+          <Route path="search" element={<SearchPage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
   )
 }

--- a/src/kaselog-ui/src/api/client.ts
+++ b/src/kaselog-ui/src/api/client.ts
@@ -1,0 +1,119 @@
+import type {
+  ApiResponse,
+  KaseResponse,
+  LogResponse,
+  LogVersionResponse,
+  SearchResult,
+  CreateKaseRequest,
+  UpdateKaseRequest,
+  CreateLogRequest,
+  UpdateLogRequest,
+  CreateVersionRequest,
+} from './types'
+
+// ── Base request helper ───────────────────────────────────────────────────────
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    ...options,
+  })
+  if (res.status === 204) return undefined as unknown as T
+  const envelope: ApiResponse<T> = await res.json() as ApiResponse<T>
+  if (!res.ok) {
+    throw new Error(envelope.error?.detail ?? `Request failed: ${res.status}`)
+  }
+  return envelope.data as T
+}
+
+// ── Kases ─────────────────────────────────────────────────────────────────────
+
+export const kases = {
+  list: (): Promise<KaseResponse[]> =>
+    request<KaseResponse[]>('/api/kases'),
+
+  get: (id: string): Promise<KaseResponse> =>
+    request<KaseResponse>(`/api/kases/${id}`),
+
+  create: (body: CreateKaseRequest): Promise<KaseResponse> =>
+    request<KaseResponse>('/api/kases', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  update: (id: string, body: UpdateKaseRequest): Promise<KaseResponse> =>
+    request<KaseResponse>(`/api/kases/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }),
+
+  delete: (id: string): Promise<void> =>
+    request<void>(`/api/kases/${id}`, { method: 'DELETE' }),
+}
+
+// ── Logs ──────────────────────────────────────────────────────────────────────
+
+export const logs = {
+  listByKase: (kaseId: string): Promise<LogResponse[]> =>
+    request<LogResponse[]>(`/api/kases/${kaseId}/logs`),
+
+  get: (id: string): Promise<LogResponse> =>
+    request<LogResponse>(`/api/logs/${id}`),
+
+  create: (kaseId: string, body: CreateLogRequest): Promise<LogResponse> =>
+    request<LogResponse>(`/api/kases/${kaseId}/logs`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  update: (id: string, body: UpdateLogRequest): Promise<LogResponse> =>
+    request<LogResponse>(`/api/logs/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }),
+
+  delete: (id: string): Promise<void> =>
+    request<void>(`/api/logs/${id}`, { method: 'DELETE' }),
+}
+
+// ── Log versions ──────────────────────────────────────────────────────────────
+
+export const versions = {
+  list: (logId: string): Promise<LogVersionResponse[]> =>
+    request<LogVersionResponse[]>(`/api/logs/${logId}/versions`),
+
+  get: (logId: string, versionId: string): Promise<LogVersionResponse> =>
+    request<LogVersionResponse>(`/api/logs/${logId}/versions/${versionId}`),
+
+  create: (logId: string, body: CreateVersionRequest): Promise<LogVersionResponse> =>
+    request<LogVersionResponse>(`/api/logs/${logId}/versions`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  restore: (logId: string, versionId: string): Promise<LogVersionResponse> =>
+    request<LogVersionResponse>(
+      `/api/logs/${logId}/versions/${versionId}/restore`,
+      { method: 'POST' },
+    ),
+}
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+export const search = {
+  query: (params: {
+    q?: string
+    kaseId?: string
+    tag?: string[]
+    from?: string
+    to?: string
+  }): Promise<SearchResult[]> => {
+    const qs = new URLSearchParams()
+    if (params.q) qs.set('q', params.q)
+    if (params.kaseId) qs.set('kaseId', params.kaseId)
+    if (params.tag) params.tag.forEach(t => qs.append('tag', t))
+    if (params.from) qs.set('from', params.from)
+    if (params.to) qs.set('to', params.to)
+    return request<SearchResult[]>(`/api/search?${qs.toString()}`)
+  },
+}

--- a/src/kaselog-ui/src/api/types.ts
+++ b/src/kaselog-ui/src/api/types.ts
@@ -1,0 +1,84 @@
+// ── API envelope ─────────────────────────────────────────────────────────────
+
+export interface ApiError {
+  type: string
+  title: string
+  status: number
+  detail: string | null
+}
+
+export interface ApiResponse<T> {
+  data: T | null
+  error: ApiError | null
+  meta: unknown
+}
+
+// ── Domain models ────────────────────────────────────────────────────────────
+
+export interface KaseResponse {
+  id: string
+  title: string
+  description: string | null
+  logCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface LogResponse {
+  id: string
+  kaseId: string
+  title: string
+  description: string | null
+  autosaveEnabled: boolean
+  content: string
+  versionCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface LogVersionResponse {
+  id: string
+  logId: string
+  content: string
+  label: string | null
+  isAutosave: boolean
+  createdAt: string
+}
+
+export interface SearchResult {
+  logId: string
+  kaseId: string
+  kaseTitle: string
+  title: string
+  content: string
+}
+
+// ── Request bodies ────────────────────────────────────────────────────────────
+
+export interface CreateKaseRequest {
+  title: string
+  description?: string | null
+}
+
+export interface UpdateKaseRequest {
+  title: string
+  description?: string | null
+}
+
+export interface CreateLogRequest {
+  title: string
+  description?: string | null
+  autosaveEnabled?: boolean
+}
+
+export interface UpdateLogRequest {
+  title: string
+  description?: string | null
+  autosaveEnabled?: boolean
+}
+
+export interface CreateVersionRequest {
+  content: string
+  label?: string | null
+  isAutosave?: boolean
+}

--- a/src/kaselog-ui/src/components/LeftNav.tsx
+++ b/src/kaselog-ui/src/components/LeftNav.tsx
@@ -1,0 +1,147 @@
+import { useState, useEffect } from 'react'
+import { Link, useMatch, useNavigate } from 'react-router-dom'
+import { kases as kasesApi } from '../api/client'
+import type { KaseResponse } from '../api/types'
+
+interface LeftNavProps {
+  onSearchOpen: () => void
+}
+
+export default function LeftNav({ onSearchOpen }: LeftNavProps) {
+  const [kaseList, setKaseList] = useState<KaseResponse[]>([])
+  const navigate = useNavigate()
+  const kaseMatch = useMatch('/kases/:id')
+  const activeKaseId = kaseMatch?.params.id
+
+  useEffect(() => {
+    kasesApi.list().then(setKaseList).catch(() => {})
+  }, [])
+
+  async function handleNewKase() {
+    try {
+      const created = await kasesApi.create({ title: 'New Kase' })
+      setKaseList(prev => [created, ...prev])
+      navigate(`/kases/${created.id}`)
+    } catch {
+      // silently ignore — shell-level error handling deferred
+    }
+  }
+
+  return (
+    <nav style={{
+      width: 'var(--nav-width)',
+      minWidth: 'var(--nav-width)',
+      background: 'var(--bg-secondary)',
+      borderRight: '1px solid var(--border)',
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+    }}>
+      {/* Logo */}
+      <div style={{ padding: '1rem 1rem 0.75rem', borderBottom: '1px solid var(--border)' }}>
+        <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '-0.03em' }}>
+          KaseLog
+        </div>
+        <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 1, letterSpacing: '0.02em' }}>
+          private ops journal
+        </div>
+      </div>
+
+      {/* New Kase */}
+      <button
+        onClick={handleNewKase}
+        style={{
+          margin: '0.6rem 0.6rem 0.25rem',
+          padding: '0.45rem 0.75rem',
+          background: 'var(--bg)',
+          border: '1px solid var(--border-mid)',
+          borderRadius: 'var(--radius)',
+          fontSize: 12,
+          fontWeight: 500,
+          color: 'var(--text-secondary)',
+          cursor: 'pointer',
+          textAlign: 'center',
+          fontFamily: 'var(--font)',
+        }}
+      >
+        + New Kase
+      </button>
+
+      {/* Section label */}
+      <div style={{
+        fontSize: 9,
+        fontWeight: 600,
+        color: 'var(--text-tertiary)',
+        padding: '0.5rem 1rem 0.25rem',
+        textTransform: 'uppercase',
+        letterSpacing: '0.08em',
+      }}>
+        Kases
+      </div>
+
+      {/* Kase list */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 0.4rem' }}>
+        {kaseList.length === 0 && (
+          <div style={{ fontSize: 12, color: 'var(--text-tertiary)', padding: '0.5rem 0.6rem', fontStyle: 'italic' }}>
+            No kases yet
+          </div>
+        )}
+        {kaseList.map(kase => {
+          const isActive = activeKaseId === kase.id
+          return (
+            <Link key={kase.id} to={`/kases/${kase.id}`} style={{ textDecoration: 'none' }}>
+              <div style={{
+                padding: '0.45rem 0.6rem',
+                borderRadius: 6,
+                cursor: 'pointer',
+                marginBottom: 1,
+                background: isActive ? 'var(--bg-tertiary)' : 'transparent',
+              }}>
+                <div style={{
+                  fontSize: 12,
+                  color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)',
+                  fontWeight: isActive ? 500 : 400,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}>
+                  {kase.title}
+                </div>
+                <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 1 }}>
+                  {kase.logCount} {kase.logCount === 1 ? 'log' : 'logs'}
+                </div>
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+
+      {/* Search — pinned */}
+      <div style={{ borderTop: '1px solid var(--border)', padding: '0.6rem', background: 'var(--bg-secondary)' }}>
+        <button
+          onClick={onSearchOpen}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            padding: '0.5rem 0.65rem',
+            borderRadius: 7,
+            background: 'var(--bg)',
+            border: '1px solid var(--border-mid)',
+            cursor: 'pointer',
+            width: '100%',
+            fontFamily: 'var(--font)',
+          }}
+        >
+          <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+            <circle cx="5.5" cy="5.5" r="4" stroke="currentColor" strokeWidth="1.5" strokeOpacity="0.4" />
+            <line x1="8.5" y1="8.5" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeOpacity="0.4" />
+          </svg>
+          <span style={{ fontSize: 12, color: 'var(--text-tertiary)', flex: 1, textAlign: 'left' }}>
+            Search logs...
+          </span>
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/src/kaselog-ui/src/components/Shell.tsx
+++ b/src/kaselog-ui/src/components/Shell.tsx
@@ -1,0 +1,21 @@
+import { Outlet, useNavigate } from 'react-router-dom'
+import LeftNav from './LeftNav'
+
+export default function Shell() {
+  const navigate = useNavigate()
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+      <LeftNav onSearchOpen={() => navigate('/search')} />
+      <main style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        background: 'var(--bg)',
+      }}>
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/src/kaselog-ui/src/index.css
+++ b/src/kaselog-ui/src/index.css
@@ -1,0 +1,88 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&family=DM+Mono:wght@400;500&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ── CSS custom properties ───────────────────────────────────────────────── */
+
+:root {
+  --accent: #1D9E75;
+  --accent-light: #E1F5EE;
+  --accent-text: #085041;
+  --bg: #ffffff;
+  --bg-secondary: #f7f6f3;
+  --bg-tertiary: #f0efe9;
+  --text-primary: #1a1a18;
+  --text-secondary: #5a5955;
+  --text-tertiary: #9a9890;
+  --border: rgba(0, 0, 0, 0.08);
+  --border-mid: rgba(0, 0, 0, 0.14);
+  --nav-width: 200px;
+  --radius: 8px;
+  --font: 'DM Sans', system-ui, sans-serif;
+  --font-mono: 'DM Mono', 'Fira Code', monospace;
+}
+
+[data-theme='dark'] {
+  --bg: #131312;
+  --bg-secondary: #1c1c1a;
+  --bg-tertiary: #242422;
+  --text-primary: #e8e6df;
+  --text-secondary: #9a9890;
+  --text-tertiary: #5a5955;
+  --border: rgba(255, 255, 255, 0.07);
+  --border-mid: rgba(255, 255, 255, 0.12);
+  --accent-light: #0a2e22;
+  --accent-text: #5dcaa5;
+}
+
+/* ── Accent presets ───────────────────────────────────────────────────────── */
+
+[data-accent='blue']   { --accent: #378ADD; --accent-light: #E6F1FB; --accent-text: #042C53; }
+[data-accent='purple'] { --accent: #7F77DD; --accent-light: #EEEDFE; --accent-text: #26215C; }
+[data-accent='coral']  { --accent: #D85A30; --accent-light: #FAECE7; --accent-text: #4A1B0C; }
+[data-accent='amber']  { --accent: #BA7517; --accent-light: #FAEEDA; --accent-text: #412402; }
+
+[data-theme='dark'][data-accent='blue']   { --accent-light: #0a1e30; --accent-text: #85B7EB; }
+[data-theme='dark'][data-accent='purple'] { --accent-light: #1e1a3a; --accent-text: #AFA9EC; }
+[data-theme='dark'][data-accent='coral']  { --accent-light: #2a1008; --accent-text: #F0997B; }
+[data-theme='dark'][data-accent='amber']  { --accent-light: #2a1e08; --accent-text: #EF9F27; }
+
+/* ── Base reset ─────────────────────────────────────────────────────────── */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text-primary);
+  height: 100vh;
+  overflow: hidden;
+  transition: background 0.2s, color 0.2s;
+}
+
+/* ── Tag colors ─────────────────────────────────────────────────────────── */
+
+.tag-green  { background: var(--accent-light); color: var(--accent-text); }
+.tag-purple { background: #EEEDFE; color: #26215C; }
+.tag-amber  { background: #FAEEDA; color: #412402; }
+.tag-blue   { background: #E6F1FB; color: #042C53; }
+.tag-coral  { background: #FAECE7; color: #4A1B0C; }
+
+[data-theme='dark'] .tag-purple { background: #1e1a3a; color: #AFA9EC; }
+[data-theme='dark'] .tag-amber  { background: #2a1e08; color: #EF9F27; }
+[data-theme='dark'] .tag-blue   { background: #0a1e30; color: #85B7EB; }
+[data-theme='dark'] .tag-coral  { background: #2a1008; color: #F0997B; }

--- a/src/kaselog-ui/src/main.tsx
+++ b/src/kaselog-ui/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import './index.css'
 import App from './App'
 
 const root = document.getElementById('root')

--- a/src/kaselog-ui/src/pages/KaseListPage.tsx
+++ b/src/kaselog-ui/src/pages/KaseListPage.tsx
@@ -1,0 +1,54 @@
+export default function KaseListPage() {
+  return (
+    <>
+      {/* Top bar */}
+      <div style={{
+        height: 48,
+        minHeight: 48,
+        borderBottom: '1px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0 1.25rem',
+        gap: '0.75rem',
+      }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '-0.02em' }}>
+          KaseLog
+        </div>
+        <div style={{ flex: 1 }} />
+        <div style={{
+          width: 30,
+          height: 30,
+          borderRadius: '50%',
+          background: 'var(--accent-light)',
+          border: '1px solid var(--border-mid)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--accent-text)',
+          cursor: 'pointer',
+        }}>
+          K
+        </div>
+      </div>
+
+      {/* Empty state */}
+      <div style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.5rem',
+      }}>
+        <div style={{ fontSize: 14, color: 'var(--text-secondary)', fontWeight: 500 }}>
+          Select a Kase
+        </div>
+        <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
+          Choose from the sidebar or create a new one
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/kaselog-ui/src/pages/KaseViewPage.tsx
+++ b/src/kaselog-ui/src/pages/KaseViewPage.tsx
@@ -1,0 +1,203 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { kases as kasesApi, logs as logsApi } from '../api/client'
+import type { KaseResponse, LogResponse } from '../api/types'
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso)
+  const now = new Date()
+  const diffMs = now.getTime() - d.getTime()
+  const diffDays = Math.floor(diffMs / 86400000)
+  if (diffDays === 0) {
+    return `today ${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
+  }
+  if (diffDays === 1) {
+    return `yesterday ${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
+  }
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+export default function KaseViewPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [kase, setKase] = useState<KaseResponse | null>(null)
+  const [logList, setLogList] = useState<LogResponse[]>([])
+
+  useEffect(() => {
+    if (!id) return
+    kasesApi.get(id).then(setKase).catch(() => {})
+    logsApi.listByKase(id).then(setLogList).catch(() => {})
+  }, [id])
+
+  async function handleNewLog() {
+    if (!id) return
+    try {
+      const log = await logsApi.create(id, { title: 'New Log' })
+      navigate(`/logs/${log.id}`)
+    } catch {
+      // silently ignore
+    }
+  }
+
+  return (
+    <>
+      {/* Top bar */}
+      <div style={{
+        height: 48,
+        minHeight: 48,
+        borderBottom: '1px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0 1.25rem',
+        gap: '0.75rem',
+        flexShrink: 0,
+      }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '-0.02em' }}>
+          {kase?.title ?? '…'}
+        </div>
+        <div style={{
+          fontSize: 11,
+          color: 'var(--text-tertiary)',
+          padding: '2px 8px',
+          background: 'var(--bg-secondary)',
+          borderRadius: 99,
+          border: '1px solid var(--border)',
+        }}>
+          {kase?.logCount ?? 0} logs
+        </div>
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={handleNewLog}
+          style={{
+            fontSize: 12,
+            fontWeight: 500,
+            color: 'var(--bg)',
+            background: 'var(--accent)',
+            padding: '5px 12px',
+            borderRadius: 6,
+            cursor: 'pointer',
+            border: 'none',
+            fontFamily: 'var(--font)',
+          }}
+        >
+          + New Log
+        </button>
+        <div style={{
+          width: 30,
+          height: 30,
+          borderRadius: '50%',
+          background: 'var(--accent-light)',
+          border: '1px solid var(--border-mid)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--accent-text)',
+          cursor: 'pointer',
+        }}>
+          K
+        </div>
+      </div>
+
+      {/* Timeline */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '1.5rem 2rem' }}>
+        {logList.length === 0 ? (
+          <p style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
+            No logs yet. Click &ldquo;+ New Log&rdquo; to get started.
+          </p>
+        ) : (
+          logList.map((log, i) => (
+            <div
+              key={log.id}
+              style={{ display: 'flex', gap: '1rem', cursor: 'pointer' }}
+              onClick={() => navigate(`/logs/${log.id}`)}
+            >
+              {/* Spine */}
+              <div style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                paddingTop: 4,
+                width: 14,
+                flexShrink: 0,
+              }}>
+                <div style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: '50%',
+                  background: i === 0 ? 'var(--accent)' : 'var(--bg-tertiary)',
+                  border: '2px solid var(--bg)',
+                  boxShadow: i === 0
+                    ? '0 0 0 1.5px var(--accent)'
+                    : '0 0 0 1.5px var(--border-mid)',
+                  flexShrink: 0,
+                }} />
+                {i < logList.length - 1 && (
+                  <div style={{
+                    width: 1,
+                    flex: 1,
+                    background: 'var(--border)',
+                    marginTop: 4,
+                    minHeight: '1.25rem',
+                  }} />
+                )}
+              </div>
+
+              {/* Entry body */}
+              <div style={{
+                flex: 1,
+                paddingBottom: '1.25rem',
+                borderBottom: i < logList.length - 1 ? '1px solid var(--border)' : 'none',
+                marginBottom: 0,
+              }}>
+                <div style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '0.5rem',
+                  marginBottom: '0.25rem',
+                }}>
+                  <div style={{
+                    fontSize: 13,
+                    fontWeight: 500,
+                    color: 'var(--text-primary)',
+                    flex: 1,
+                    lineHeight: 1.3,
+                  }}>
+                    {log.title}
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', flexShrink: 0 }}>
+                    <span style={{
+                      fontSize: 10,
+                      color: 'var(--text-tertiary)',
+                      padding: '1px 6px',
+                      background: 'var(--bg-secondary)',
+                      border: '1px solid var(--border)',
+                      borderRadius: 4,
+                      fontFamily: 'var(--font-mono)',
+                    }}>
+                      v{log.versionCount}
+                    </span>
+                    <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>
+                      {formatTimestamp(log.updatedAt)}
+                    </span>
+                  </div>
+                </div>
+                {log.description && (
+                  <div style={{
+                    fontSize: 12,
+                    color: 'var(--text-secondary)',
+                    lineHeight: 1.6,
+                    marginBottom: '0.45rem',
+                  }}>
+                    {log.description}
+                  </div>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/kaselog-ui/src/pages/LogViewPage.tsx
+++ b/src/kaselog-ui/src/pages/LogViewPage.tsx
@@ -1,0 +1,275 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { logs as logsApi } from '../api/client'
+import type { LogResponse } from '../api/types'
+
+export default function LogViewPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [log, setLog] = useState<LogResponse | null>(null)
+  const [panelOpen, setPanelOpen] = useState(false)
+
+  useEffect(() => {
+    if (!id) return
+    logsApi.get(id).then(setLog).catch(() => {})
+  }, [id])
+
+  async function handleNewLog() {
+    if (!log) return
+    try {
+      const created = await logsApi.create(log.kaseId, { title: 'New Log' })
+      navigate(`/logs/${created.id}`)
+    } catch {
+      // silently ignore
+    }
+  }
+
+  if (!log) {
+    return (
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <p style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>Loading…</p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {/* Top bar */}
+      <div style={{
+        height: 48,
+        minHeight: 48,
+        borderBottom: '1px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0 1.25rem',
+        gap: '0.5rem',
+        background: 'var(--bg)',
+        flexShrink: 0,
+      }}>
+        <button
+          onClick={() => navigate(`/kases/${log.kaseId}`)}
+          style={{
+            fontSize: 12,
+            color: 'var(--text-tertiary)',
+            cursor: 'pointer',
+            padding: '4px 8px',
+            borderRadius: 5,
+            background: 'transparent',
+            border: 'none',
+            fontFamily: 'var(--font)',
+            whiteSpace: 'nowrap',
+            flexShrink: 0,
+          }}
+        >
+          ← Kase
+        </button>
+        <span style={{ fontSize: 12, color: 'var(--border-mid)', flexShrink: 0 }}>/</span>
+        <span style={{
+          fontSize: 13,
+          fontWeight: 500,
+          color: 'var(--text-primary)',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          minWidth: 0,
+        }}>
+          {log.title}
+        </span>
+        <div style={{ flex: 1, minWidth: '0.5rem' }} />
+        <span style={{
+          fontSize: 10,
+          color: 'var(--text-tertiary)',
+          padding: '3px 9px',
+          background: 'var(--bg-secondary)',
+          border: '1px solid var(--border)',
+          borderRadius: 5,
+          fontFamily: 'var(--font-mono)',
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+        }}>
+          v{log.versionCount} · history
+        </span>
+        <span style={{ fontSize: 10, color: 'var(--text-tertiary)', whiteSpace: 'nowrap', flexShrink: 0 }}>
+          saved just now
+        </span>
+        <button
+          onClick={handleNewLog}
+          style={{
+            fontSize: 12,
+            fontWeight: 500,
+            color: 'white',
+            background: 'var(--accent)',
+            padding: '5px 12px',
+            borderRadius: 6,
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+            flexShrink: 0,
+            border: 'none',
+            fontFamily: 'var(--font)',
+          }}
+        >
+          + New Log
+        </button>
+        <div style={{
+          width: 30,
+          height: 30,
+          borderRadius: '50%',
+          background: 'var(--accent-light)',
+          border: '1px solid var(--border-mid)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--accent-text)',
+          cursor: 'pointer',
+          flexShrink: 0,
+        }}>
+          K
+        </div>
+      </div>
+
+      {/* Editor area */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden', position: 'relative' }}>
+
+        {/* Editor column */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+
+          {/* Toolbar placeholder */}
+          <div style={{
+            borderBottom: '1px solid var(--border)',
+            padding: '0 1.5rem',
+            display: 'flex',
+            alignItems: 'center',
+            background: 'var(--bg)',
+            height: 36,
+            minHeight: 36,
+            flexShrink: 0,
+            gap: '2px',
+            overflowX: 'auto',
+          }}>
+            {['H1','H2','H3'].map(t => (
+              <span key={t} style={{ padding: '4px 7px', borderRadius: 5, fontSize: 11, fontWeight: 500, color: 'var(--text-tertiary)', cursor: 'pointer' }}>{t}</span>
+            ))}
+            <span style={{ width: 1, height: 14, background: 'var(--border-mid)', margin: '0 3px' }} />
+            {['≡','1.','☐'].map(t => (
+              <span key={t} style={{ padding: '4px 7px', borderRadius: 5, fontSize: 11, fontWeight: 500, color: 'var(--text-tertiary)', cursor: 'pointer' }}>{t}</span>
+            ))}
+            <span style={{ width: 1, height: 14, background: 'var(--border-mid)', margin: '0 3px' }} />
+            {['</>', '"', '▶', '∑'].map(t => (
+              <span key={t} style={{ padding: '4px 7px', borderRadius: 5, fontSize: 11, fontWeight: 500, color: 'var(--text-tertiary)', cursor: 'pointer' }}>{t}</span>
+            ))}
+            <span style={{ width: 1, height: 14, background: 'var(--border-mid)', margin: '0 3px' }} />
+            {['↩','↪'].map(t => (
+              <span key={t} style={{ padding: '4px 7px', borderRadius: 5, fontSize: 11, fontWeight: 500, color: 'var(--text-tertiary)', cursor: 'pointer' }}>{t}</span>
+            ))}
+          </div>
+
+          {/* Canvas */}
+          <div style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: '2.5rem 0',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}>
+            <div style={{ width: '100%', maxWidth: 680, padding: '0 3rem' }}>
+              <h1 style={{
+                fontSize: 26,
+                fontWeight: 600,
+                color: 'var(--text-primary)',
+                letterSpacing: '-0.03em',
+                lineHeight: 1.2,
+                marginBottom: '0.4rem',
+                fontFamily: 'var(--font)',
+              }}>
+                {log.title}
+              </h1>
+              <div style={{
+                fontSize: 11,
+                color: 'var(--text-tertiary)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.45rem',
+                marginBottom: '2rem',
+              }}>
+                <span>{new Date(log.updatedAt).toLocaleString()}</span>
+                <span style={{ width: 3, height: 3, borderRadius: '50%', background: 'var(--border-mid)', display: 'inline-block' }} />
+                <span>version {log.versionCount} of {log.versionCount}</span>
+              </div>
+              <div style={{ color: 'var(--text-secondary)', lineHeight: 1.8, fontSize: 15 }}>
+                {log.content
+                  ? log.content
+                  : <em style={{ color: 'var(--text-tertiary)' }}>Start writing…</em>
+                }
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Settings panel */}
+        {panelOpen && (
+          <div style={{
+            width: 260,
+            minWidth: 260,
+            background: 'var(--bg-secondary)',
+            borderLeft: '1px solid var(--border-mid)',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            flexShrink: 0,
+          }}>
+            <div style={{ padding: '0.75rem 1rem', borderBottom: '1px solid var(--border)' }}>
+              <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-primary)' }}>Log settings</div>
+            </div>
+            <div style={{ flex: 1, overflowY: 'auto', padding: '0.75rem 1rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+              <div>
+                <div style={{ fontSize: 9, fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: '0.3rem' }}>Info</div>
+                <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>
+                  Created {new Date(log.createdAt).toLocaleDateString()}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Edge tab */}
+        <div style={{
+          position: 'absolute',
+          right: panelOpen ? 260 : 0,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          zIndex: 30,
+          transition: 'right 0.25s ease',
+        }}>
+          <div
+            onClick={() => setPanelOpen(o => !o)}
+            style={{
+              background: 'var(--bg-secondary)',
+              border: '1px solid var(--border-mid)',
+              borderRight: 'none',
+              borderRadius: '8px 0 0 8px',
+              padding: '0.6rem 0.35rem',
+              cursor: 'pointer',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 4,
+              boxShadow: '-2px 0 8px rgba(0,0,0,0.06)',
+            }}
+          >
+            <span style={{ fontSize: 14, color: 'var(--text-tertiary)', lineHeight: 1 }}>
+              {panelOpen ? '›' : '‹'}
+            </span>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 3, alignItems: 'center' }}>
+              {[0, 1, 2].map(i => (
+                <div key={i} style={{ width: 2.5, height: 2.5, borderRadius: '50%', background: 'var(--text-tertiary)', opacity: 0.5 }} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/kaselog-ui/src/pages/SearchPage.tsx
+++ b/src/kaselog-ui/src/pages/SearchPage.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { search as searchApi } from '../api/client'
+import type { SearchResult } from '../api/types'
+
+export default function SearchPage() {
+  const navigate = useNavigate()
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [searched, setSearched] = useState(false)
+
+  async function handleSearch(q: string) {
+    setQuery(q)
+    if (!q.trim()) {
+      setResults([])
+      setSearched(false)
+      return
+    }
+    try {
+      const r = await searchApi.query({ q: q.trim() })
+      setResults(r)
+      setSearched(true)
+    } catch {
+      setResults([])
+      setSearched(true)
+    }
+  }
+
+  return (
+    <>
+      {/* Top bar with search input */}
+      <div style={{
+        height: 48,
+        minHeight: 48,
+        borderBottom: '1px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0 1.25rem',
+        gap: '0.75rem',
+        flexShrink: 0,
+      }}>
+        <svg width="15" height="15" viewBox="0 0 13 13" fill="none" style={{ flexShrink: 0 }}>
+          <circle cx="5.5" cy="5.5" r="4" stroke="currentColor" strokeWidth="1.5" strokeOpacity="0.4" />
+          <line x1="8.5" y1="8.5" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeOpacity="0.4" />
+        </svg>
+        <input
+          type="text"
+          placeholder="Search logs..."
+          value={query}
+          onChange={e => handleSearch(e.target.value)}
+          autoFocus
+          style={{
+            flex: 1,
+            border: 'none',
+            outline: 'none',
+            fontSize: 14,
+            background: 'transparent',
+            color: 'var(--text-primary)',
+            fontFamily: 'var(--font)',
+          }}
+        />
+        <div style={{
+          width: 30,
+          height: 30,
+          borderRadius: '50%',
+          background: 'var(--accent-light)',
+          border: '1px solid var(--border-mid)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--accent-text)',
+          cursor: 'pointer',
+        }}>
+          K
+        </div>
+      </div>
+
+      {/* Results */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '1.5rem 2rem' }}>
+        {!searched && (
+          <p style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>Type to search logs…</p>
+        )}
+        {searched && results.length === 0 && (
+          <p style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>No results for &ldquo;{query}&rdquo;</p>
+        )}
+        {results.length > 0 && (
+          <div style={{ marginBottom: '0.75rem', fontSize: 12, color: 'var(--text-tertiary)' }}>
+            {results.length} result{results.length !== 1 ? 's' : ''}
+          </div>
+        )}
+        {results.map(r => (
+          <div
+            key={r.logId}
+            onClick={() => navigate(`/logs/${r.logId}`)}
+            style={{
+              marginBottom: '0.75rem',
+              padding: '0.75rem 1rem',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius)',
+              cursor: 'pointer',
+              background: 'var(--bg)',
+            }}
+          >
+            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-primary)', marginBottom: '0.2rem' }}>
+              {r.title}
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: '0.35rem' }}>
+              {r.kaseTitle}
+            </div>
+            <div style={{
+              fontSize: 12,
+              color: 'var(--text-secondary)',
+              lineHeight: 1.5,
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            } as React.CSSProperties}>
+              {r.content}
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/src/kaselog-ui/tailwind.config.js
+++ b/src/kaselog-ui/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary

- React Router with four routes: `/`, `/kases/:id`, `/logs/:id`, `/search`
- Persistent 200px left nav (LeftNav) fetches kases from `GET /api/kases` on mount, shows active state, pinned search button
- Shell layout component wraps all pages with left nav + `<Outlet>`
- CSS custom properties from HTML artifacts: accent colors (5 presets), light/dark themes, DM Sans + DM Mono fonts
- Tailwind CSS v3 configured with postcss
- Typed API client covering all endpoints (kases, logs, versions, search) with envelope unwrapping
- KaseViewPage: timeline with spine dots, version badges, relative timestamps, "+ New Log" action
- LogViewPage: topbar with back navigation, editor toolbar placeholder, canvas at max-width 680px, edge tab for settings panel
- SearchPage: live search input in top bar, result cards with kase context
- KaseListPage: empty state directing user to sidebar

## Test plan

- [ ] `docker compose up --build` succeeds
- [ ] All four routes render without errors: `/`, `/kases/:id`, `/logs/:id`, `/search`
- [ ] Left nav loads Kase list from `GET /api/kases`
- [ ] Clicking a Kase navigates to `/kases/:id` with active highlight in nav
- [ ] Timeline shows logs with spine dots, version badges, timestamps
- [ ] Creating a new log navigates to `/logs/:id`
- [ ] Log view shows back arrow → `/kases/:id`, version pill, edge tab toggle
- [ ] Search input fetches from `/api/search`
- [ ] Shell layout matches HTML artifacts (200px nav, 48px topbar, DM Sans font)

🤖 Generated with [Claude Code](https://claude.com/claude-code)