### PR TITLE
feat: add Swagger/OpenAPI documentation to KaseLog API

### DIFF
--- a/src/KaseLog.Api/Controllers/KaseLogsController.cs
+++ b/src/KaseLog.Api/Controllers/KaseLogsController.cs
@@ -5,20 +5,28 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace KaseLog.Api.Controllers;
 
+/// <summary>Operations for Logs scoped to a specific Kase.</summary>
 [ApiController]
 [Route("api/kases/{kaseId:guid}/logs")]
+[Produces("application/json")]
 public sealed class KaseLogsController : ControllerBase
 {
     private readonly ILogRepository _logs;
     private readonly IKaseRepository _kases;
 
+    /// <summary>Initialises a new instance of <see cref="KaseLogsController"/>.</summary>
     public KaseLogsController(ILogRepository logs, IKaseRepository kases)
     {
         _logs = logs;
         _kases = kases;
     }
 
+    /// <summary>Returns all Logs belonging to a Kase.</summary>
+    /// <param name="kaseId">The GUID of the parent Kase.</param>
+    /// <returns>A list of Logs for the Kase, newest first.</returns>
     [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<LogResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<LogResponse>>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetByKase(Guid kaseId)
     {
         var kase = await _kases.GetByIdAsync(kaseId);
@@ -29,7 +37,18 @@ public sealed class KaseLogsController : ControllerBase
         return Ok(ApiResponse<IEnumerable<LogResponse>>.Success(logs));
     }
 
+    /// <summary>Creates a new Log inside a Kase.</summary>
+    /// <remarks>
+    /// Creates the Log and its initial empty <c>LogVersion</c> in a single atomic transaction.
+    /// The FTS5 search index is updated in the same transaction.
+    /// </remarks>
+    /// <param name="kaseId">The GUID of the parent Kase.</param>
+    /// <param name="request">Title, optional description, and autosave preference for the new Log.</param>
+    /// <returns>The newly created Log including its initial content and version count.</returns>
     [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Create(Guid kaseId, [FromBody] CreateLogRequest request)
     {
         var log = await _logs.CreateAsync(kaseId, request.Title, request.Description, request.AutosaveEnabled);

--- a/src/KaseLog.Api/Controllers/KasesController.cs
+++ b/src/KaseLog.Api/Controllers/KasesController.cs
@@ -5,22 +5,33 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace KaseLog.Api.Controllers;
 
+/// <summary>CRUD operations for Kases.</summary>
 [ApiController]
 [Route("api/kases")]
+[Produces("application/json")]
 public sealed class KasesController : ControllerBase
 {
     private readonly IKaseRepository _kases;
 
+    /// <summary>Initialises a new instance of <see cref="KasesController"/>.</summary>
     public KasesController(IKaseRepository kases) => _kases = kases;
 
+    /// <summary>Returns all Kases.</summary>
+    /// <returns>A list of every Kase in the system.</returns>
     [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<KaseResponse>>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetAll()
     {
         var kases = await _kases.GetAllAsync();
         return Ok(ApiResponse<IEnumerable<KaseResponse>>.Success(kases));
     }
 
+    /// <summary>Creates a new Kase.</summary>
+    /// <param name="request">Title and optional description for the new Kase.</param>
+    /// <returns>The newly created Kase.</returns>
     [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<KaseResponse>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse<KaseResponse>), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Create([FromBody] CreateKaseRequest request)
     {
         var kase = await _kases.CreateAsync(request.Title, request.Description);
@@ -28,7 +39,12 @@ public sealed class KasesController : ControllerBase
             ApiResponse<KaseResponse>.Success(kase));
     }
 
+    /// <summary>Returns a single Kase by ID.</summary>
+    /// <param name="id">The GUID of the Kase to retrieve.</param>
+    /// <returns>The Kase, or 404 if not found.</returns>
     [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<KaseResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<KaseResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetById(Guid id)
     {
         var kase = await _kases.GetByIdAsync(id);
@@ -37,7 +53,14 @@ public sealed class KasesController : ControllerBase
         return Ok(ApiResponse<KaseResponse>.Success(kase));
     }
 
+    /// <summary>Updates the title and description of an existing Kase.</summary>
+    /// <param name="id">The GUID of the Kase to update.</param>
+    /// <param name="request">Updated title and optional description.</param>
+    /// <returns>The updated Kase, or 404 if not found.</returns>
     [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<KaseResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<KaseResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<KaseResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Update(Guid id, [FromBody] UpdateKaseRequest request)
     {
         var kase = await _kases.UpdateAsync(id, request.Title, request.Description);
@@ -46,7 +69,12 @@ public sealed class KasesController : ControllerBase
         return Ok(ApiResponse<KaseResponse>.Success(kase));
     }
 
+    /// <summary>Deletes a Kase and all its Logs.</summary>
+    /// <param name="id">The GUID of the Kase to delete.</param>
+    /// <returns>204 No Content on success, or 404 if not found.</returns>
     [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ApiResponse<KaseResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete(Guid id)
     {
         var deleted = await _kases.DeleteAsync(id);

--- a/src/KaseLog.Api/Controllers/LogsController.cs
+++ b/src/KaseLog.Api/Controllers/LogsController.cs
@@ -5,15 +5,29 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace KaseLog.Api.Controllers;
 
+/// <summary>CRUD operations for Logs and their version history.</summary>
 [ApiController]
 [Route("api/logs")]
+[Produces("application/json")]
 public sealed class LogsController : ControllerBase
 {
     private readonly ILogRepository _logs;
 
+    /// <summary>Initialises a new instance of <see cref="LogsController"/>.</summary>
     public LogsController(ILogRepository logs) => _logs = logs;
 
+    // ── Logs ──────────────────────────────────────────────────────────────────
+
+    /// <summary>Returns a single Log by ID.</summary>
+    /// <remarks>
+    /// The <c>Content</c> field in the response is taken from the most recent
+    /// <c>LogVersion</c> for this Log.
+    /// </remarks>
+    /// <param name="id">The GUID of the Log to retrieve.</param>
+    /// <returns>The Log with its current content, or 404 if not found.</returns>
     [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetById(Guid id)
     {
         var log = await _logs.GetByIdAsync(id);
@@ -22,7 +36,18 @@ public sealed class LogsController : ControllerBase
         return Ok(ApiResponse<LogResponse>.Success(log));
     }
 
+    /// <summary>Updates the metadata of an existing Log.</summary>
+    /// <remarks>
+    /// Updates title, description, and autosave preference. Does not create a new
+    /// version — use <c>POST /api/logs/{logId}/versions</c> to save content changes.
+    /// </remarks>
+    /// <param name="id">The GUID of the Log to update.</param>
+    /// <param name="request">Updated title, description, and autosave flag.</param>
+    /// <returns>The updated Log, or 404 if not found.</returns>
     [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Update(Guid id, [FromBody] UpdateLogRequest request)
     {
         var log = await _logs.UpdateAsync(id, request.Title, request.Description, request.AutosaveEnabled);
@@ -31,7 +56,12 @@ public sealed class LogsController : ControllerBase
         return Ok(ApiResponse<LogResponse>.Success(log));
     }
 
+    /// <summary>Deletes a Log and all its versions.</summary>
+    /// <param name="id">The GUID of the Log to delete.</param>
+    /// <returns>204 No Content on success, or 404 if not found.</returns>
     [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ApiResponse<LogResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete(Guid id)
     {
         var deleted = await _logs.DeleteAsync(id);
@@ -42,7 +72,13 @@ public sealed class LogsController : ControllerBase
 
     // ── Log Versions ──────────────────────────────────────────────────────────
 
+    /// <summary>Returns the full version history for a Log.</summary>
+    /// <remarks>Versions are returned newest first. The first item is always the current version.</remarks>
+    /// <param name="logId">The GUID of the parent Log.</param>
+    /// <returns>All versions for the Log, or 404 if the Log does not exist.</returns>
     [HttpGet("{logId:guid}/versions")]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<LogVersionResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<LogVersionResponse>>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetVersions(Guid logId)
     {
         var log = await _logs.GetByIdAsync(logId);
@@ -53,7 +89,22 @@ public sealed class LogsController : ControllerBase
         return Ok(ApiResponse<IEnumerable<LogVersionResponse>>.Success(versions));
     }
 
+    /// <summary>Saves a new version of a Log's content.</summary>
+    /// <remarks>
+    /// Set <c>IsAutosave</c> to <c>true</c> for background saves and <c>false</c> for
+    /// explicit user saves. Provide a <c>Label</c> to create a named checkpoint —
+    /// named checkpoints are visually distinct in the version history UI.
+    /// The FTS5 search index is updated in the same transaction.
+    /// </remarks>
+    /// <param name="logId">The GUID of the Log to version.</param>
+    /// <param name="request">
+    /// Content (markdown), optional label, and whether this is an autosave.
+    /// </param>
+    /// <returns>The newly created version, or 404 if the Log does not exist.</returns>
     [HttpPost("{logId:guid}/versions")]
+    [ProducesResponseType(typeof(ApiResponse<LogVersionResponse>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse<LogVersionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<LogVersionResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> AddVersion(Guid logId, [FromBody] CreateVersionRequest request)
     {
         var version = await _logs.AddVersionAsync(logId, request.Content, request.Label, request.IsAutosave);
@@ -64,7 +115,13 @@ public sealed class LogsController : ControllerBase
             ApiResponse<LogVersionResponse>.Success(version));
     }
 
+    /// <summary>Returns a specific version of a Log by version ID.</summary>
+    /// <param name="logId">The GUID of the parent Log.</param>
+    /// <param name="versionId">The GUID of the version to retrieve.</param>
+    /// <returns>The requested version, or 404 if either ID is not found.</returns>
     [HttpGet("{logId:guid}/versions/{versionId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<LogVersionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<LogVersionResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetVersionById(Guid logId, Guid versionId)
     {
         var version = await _logs.GetVersionByIdAsync(logId, versionId);
@@ -74,7 +131,17 @@ public sealed class LogsController : ControllerBase
         return Ok(ApiResponse<LogVersionResponse>.Success(version));
     }
 
+    /// <summary>Restores a prior version by creating a new version with its content.</summary>
+    /// <remarks>
+    /// Restore never mutates history. A new <c>LogVersion</c> is inserted with
+    /// the restored content, incrementing the version count.
+    /// </remarks>
+    /// <param name="logId">The GUID of the parent Log.</param>
+    /// <param name="versionId">The GUID of the version to restore from.</param>
+    /// <returns>The new version created from the restore, or 404 if either ID is not found.</returns>
     [HttpPost("{logId:guid}/versions/{versionId:guid}/restore")]
+    [ProducesResponseType(typeof(ApiResponse<LogVersionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<LogVersionResponse>), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> RestoreVersion(Guid logId, Guid versionId)
     {
         var version = await _logs.RestoreVersionAsync(logId, versionId);

--- a/src/KaseLog.Api/KaseLog.Api.csproj
+++ b/src/KaseLog.Api/KaseLog.Api.csproj
@@ -5,12 +5,14 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>CS1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/KaseLog.Api/Models/ImageUploadResponse.cs
+++ b/src/KaseLog.Api/Models/ImageUploadResponse.cs
@@ -1,0 +1,16 @@
+namespace KaseLog.Api.Models;
+
+/// <summary>Returned after a successful image upload.</summary>
+public sealed class ImageUploadResponse
+{
+    /// <summary>
+    /// 40-character alphanumeric uppercase UID assigned to this image.
+    /// Example: <c>A3F9K2M7RX4B9NPQ2WYH6JDCT8VE1SKL0F5GZ3U</c>
+    /// </summary>
+    public string Uid { get; init; } = string.Empty;
+
+    /// <summary>
+    /// URL to retrieve the image via <c>GET /api/images/{uid}</c>.
+    /// </summary>
+    public string Url { get; init; } = string.Empty;
+}

--- a/src/KaseLog.Api/Models/TagDto.cs
+++ b/src/KaseLog.Api/Models/TagDto.cs
@@ -1,0 +1,14 @@
+namespace KaseLog.Api.Models;
+
+/// <summary>Represents a tag that can be applied to a Log.</summary>
+public sealed class TagDto
+{
+    /// <summary>The unique identifier for the tag.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>The normalised (lowercase) tag name.</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>When the tag was first created.</summary>
+    public DateTime CreatedAt { get; init; }
+}

--- a/src/KaseLog.Api/Program.cs
+++ b/src/KaseLog.Api/Program.cs
@@ -1,6 +1,8 @@
 using KaseLog.Api.Data;
 using KaseLog.Api.Data.Sqlite;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
+using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -57,6 +59,24 @@ builder.Services.AddControllers()
         };
     });
 
+// ── Swagger / OpenAPI (development only) ─────────────────────────────────────
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "KaseLog API",
+        Version = "v1",
+        Description = "KaseLog is a private ops journal for the solo technical operator. " +
+                      "Open a Kase when something needs attention, and write Logs as the work unfolds.",
+    });
+
+    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    if (File.Exists(xmlPath))
+        options.IncludeXmlComments(xmlPath);
+});
+
 var app = builder.Build();
 
 // ── Data directories ─────────────────────────────────────────────────────────
@@ -67,6 +87,13 @@ Directory.CreateDirectory(Path.Combine(dataDir, "images"));
 var schemaInitializer = app.Services.GetRequiredService<ISchemaInitializer>();
 await schemaInitializer.InitializeAsync();
 
+// ── Swagger UI (development only) ─────────────────────────────────────────────
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "KaseLog API v1"));
+}
+
 // ── Middleware ────────────────────────────────────────────────────────────────
 app.UseDefaultFiles();
 app.UseStaticFiles();
@@ -74,7 +101,10 @@ app.UseStaticFiles();
 app.MapControllers();
 
 // Health check — no database dependency
-app.MapGet("/health", () => Results.Ok(new { status = "ok", version = "1.0.0" }));
+app.MapGet("/health", () => Results.Ok(new { status = "ok", version = "1.0.0" }))
+   .WithName("Health")
+   .WithSummary("Returns API health status.")
+   .WithTags("Health");
 
 // SPA fallback — return index.html for any unmatched route
 app.MapFallbackToFile("index.html");


### PR DESCRIPTION
## Summary

- Adds `Swashbuckle.AspNetCore 7.3.1` to `KaseLog.Api.csproj`
- Enables XML documentation file generation (`GenerateDocumentationFile`)
- Configures Swagger UI at `/swagger` — **development only**, gated by `app.Environment.IsDevelopment()`; not exposed in the production Docker image
- Sets OpenAPI metadata: title `KaseLog API`, version `v1`, description from AGENTS.md product philosophy
- Adds full `/// <summary>`, `/// <param>`, `/// <returns>`, `/// <remarks>` XML doc comments to every controller action
- Adds typed `[ProducesResponseType]` attributes with `ApiResponse<T>` envelope types on all responses (200, 201, 204, 400, 404)

**Controllers documented:**
- `KasesController` — GET all, POST create, GET by ID, PUT update, DELETE
- `KaseLogsController` — GET logs by kase, POST create log (notes atomic transaction + FTS5 update)
- `LogsController` — log CRUD; versions list, add, get by ID, restore (notes immutable history guarantee)
- `/health` endpoint — annotated with `WithSummary` / `WithTags`

**New schema models:**
- `TagDto` — for future Tags API documentation
- `ImageUploadResponse` — for future Images API documentation

## Test plan

- [ ] `GET /swagger` loads Swagger UI in development (`ASPNETCORE_ENVIRONMENT=Development`)
- [ ] All endpoints visible with summaries, parameter docs, and response schemas
- [ ] `dotnet test` — 37/37 pass
- [ ] `docker compose build` succeeds with no errors or warnings
- [ ] Swagger UI is not accessible when `ASPNETCORE_ENVIRONMENT=Production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)