### PR TITLE
fix: resolve Swagger UI blank page

### DIFF
--- a/src/KaseLog.Api/Program.cs
+++ b/src/KaseLog.Api/Program.cs
@@ -87,12 +87,9 @@ Directory.CreateDirectory(Path.Combine(dataDir, "images"));
 var schemaInitializer = app.Services.GetRequiredService<ISchemaInitializer>();
 await schemaInitializer.InitializeAsync();
 
-// ── Swagger UI (development only) ─────────────────────────────────────────────
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "KaseLog API v1"));
-}
+// ── Swagger UI ────────────────────────────────────────────────────────────────
+app.UseSwagger();
+app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "KaseLog API v1"));
 
 // ── Middleware ────────────────────────────────────────────────────────────────
 app.UseDefaultFiles();


### PR DESCRIPTION
## Summary
- Swagger UI at `/swagger` was loading a blank page
- `/swagger/v1/swagger.json` was returning 404

## Root cause
`UseSwagger()` and `UseSwaggerUI()` were wrapped in `if (app.Environment.IsDevelopment())`. `ASPNETCORE_ENVIRONMENT` is unset in normal run and Docker contexts, which causes ASP.NET Core to default to **Production** — so the Swagger middleware was never registered.

## Fix
Removed the `IsDevelopment()` guard. KaseLog is a self-hosted personal tool with no public exposure, so Swagger is appropriate in all environments. The `AddSwaggerGen()` registration was already unconditional; the middleware now matches.

## Verified
- `GET /swagger/` → 200 OK, UI loads with all endpoints
- `GET /swagger/v1/swagger.json` → valid OpenAPI 3.0.1 JSON (7 paths)
- `GET /health` → 200 OK
- Docker build succeeds

## Test plan
- [ ] `docker compose build && docker run ...` — container starts cleanly
- [ ] `GET /swagger` — Swagger UI loads with all endpoints visible
- [ ] `GET /swagger/v1/swagger.json` — returns valid JSON
- [ ] `GET /health` — returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)