### PR TITLE
feat: implement Kase timeline view with tags, hover, and 404 states

### DIFF
--- a/src/KaseLog.Api/Data/Sqlite/SqliteLogRepository.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteLogRepository.cs
@@ -12,15 +12,20 @@ public sealed class SqliteLogRepository : ILogRepository
     public async Task<IEnumerable<LogResponse>> GetByKaseIdAsync(Guid kaseId)
     {
         using var conn = await _db.OpenAsync();
-        var rows = await conn.QueryAsync<LogRow>("""
+        var rows = (await conn.QueryAsync<LogRow>("""
             SELECT l.Id, l.KaseId, l.Title, l.Description, l.AutosaveEnabled, l.CreatedAt, l.UpdatedAt,
                    COALESCE((SELECT Content FROM LogVersions WHERE LogId = l.Id ORDER BY CreatedAt DESC LIMIT 1), '') AS Content,
                    (SELECT COUNT(*) FROM LogVersions WHERE LogId = l.Id) AS VersionCount
             FROM Logs l
             WHERE l.KaseId = @KaseId
             ORDER BY l.UpdatedAt DESC
-            """, new { KaseId = kaseId.ToString() });
-        return rows.Select(Map);
+            """, new { KaseId = kaseId.ToString() })).ToList();
+
+        if (rows.Count == 0) return [];
+
+        var logIds = rows.Select(r => r.Id).ToList();
+        var tagsByLogId = await FetchTagsByLogIdsAsync(conn, logIds);
+        return rows.Select(r => Map(r, tagsByLogId.GetValueOrDefault(r.Id, [])));
     }
 
     public async Task<LogResponse?> GetByIdAsync(Guid id)
@@ -33,7 +38,10 @@ public sealed class SqliteLogRepository : ILogRepository
             FROM Logs l
             WHERE l.Id = @Id
             """, new { Id = id.ToString() });
-        return row is null ? null : Map(row);
+        if (row is null) return null;
+
+        var tagsByLogId = await FetchTagsByLogIdsAsync(conn, [row.Id]);
+        return Map(row, tagsByLogId.GetValueOrDefault(row.Id, []));
     }
 
     public async Task<LogResponse?> CreateAsync(Guid kaseId, string title, string? description, bool autosaveEnabled)
@@ -193,7 +201,29 @@ public sealed class SqliteLogRepository : ILogRepository
         return await GetVersionByIdAsync(logId, newVersionId);
     }
 
-    private static LogResponse Map(LogRow row) => new()
+    private static async Task<Dictionary<string, IReadOnlyList<TagDto>>> FetchTagsByLogIdsAsync(
+        System.Data.IDbConnection conn, IEnumerable<string> logIds)
+    {
+        var ids = logIds.ToList();
+        if (ids.Count == 0) return [];
+
+        var tagRows = await conn.QueryAsync<TagRow>(
+            "SELECT t.Id, t.Name, t.CreatedAt, lt.LogId FROM Tags t JOIN LogTags lt ON lt.TagId = t.Id WHERE lt.LogId IN @Ids",
+            new { Ids = ids });
+
+        return tagRows
+            .GroupBy(r => r.LogId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<TagDto>)g.Select(r => new TagDto
+                {
+                    Id = Guid.Parse(r.Id),
+                    Name = r.Name,
+                    CreatedAt = DateTime.Parse(r.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+                }).ToList());
+    }
+
+    private static LogResponse Map(LogRow row, IReadOnlyList<TagDto> tags) => new()
     {
         Id = Guid.Parse(row.Id),
         KaseId = Guid.Parse(row.KaseId),
@@ -202,6 +232,7 @@ public sealed class SqliteLogRepository : ILogRepository
         AutosaveEnabled = row.AutosaveEnabled != 0,
         Content = row.Content,
         VersionCount = (int)row.VersionCount,
+        Tags = tags,
         CreatedAt = DateTime.Parse(row.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
         UpdatedAt = DateTime.Parse(row.UpdatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
     };
@@ -237,5 +268,13 @@ public sealed class SqliteLogRepository : ILogRepository
         public string? Label { get; set; }
         public int IsAutosave { get; set; }
         public string CreatedAt { get; set; } = string.Empty;
+    }
+
+    private sealed class TagRow
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string CreatedAt { get; set; } = string.Empty;
+        public string LogId { get; set; } = string.Empty;
     }
 }

--- a/src/KaseLog.Api/Models/LogResponse.cs
+++ b/src/KaseLog.Api/Models/LogResponse.cs
@@ -9,6 +9,7 @@ public sealed class LogResponse
     public bool AutosaveEnabled { get; init; }
     public string Content { get; init; } = string.Empty;
     public int VersionCount { get; init; }
+    public IReadOnlyList<TagDto> Tags { get; init; } = [];
     public DateTime CreatedAt { get; init; }
     public DateTime UpdatedAt { get; init; }
 }

--- a/src/kaselog-ui/src/api/types.ts
+++ b/src/kaselog-ui/src/api/types.ts
@@ -24,6 +24,12 @@ export interface KaseResponse {
   updatedAt: string
 }
 
+export interface TagResponse {
+  id: string
+  name: string
+  createdAt: string
+}
+
 export interface LogResponse {
   id: string
   kaseId: string
@@ -32,6 +38,7 @@ export interface LogResponse {
   autosaveEnabled: boolean
   content: string
   versionCount: number
+  tags: TagResponse[]
   createdAt: string
   updatedAt: string
 }

--- a/src/kaselog-ui/src/pages/KaseViewPage.tsx
+++ b/src/kaselog-ui/src/pages/KaseViewPage.tsx
@@ -3,11 +3,26 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { kases as kasesApi, logs as logsApi } from '../api/client'
 import type { KaseResponse, LogResponse } from '../api/types'
 
+// ── Tag color palette ─────────────────────────────────────────────────────────
+
+const TAG_PALETTES = ['green', 'purple', 'amber', 'blue', 'coral'] as const
+type TagPalette = (typeof TAG_PALETTES)[number]
+
+/** Deterministic hash: same tag name always maps to the same palette. */
+function tagColorClass(name: string): TagPalette {
+  let hash = 0
+  for (let i = 0; i < name.length; i++) {
+    hash = (Math.imul(31, hash) + name.charCodeAt(i)) | 0
+  }
+  return TAG_PALETTES[Math.abs(hash) % TAG_PALETTES.length]
+}
+
+// ── Timestamp formatting ──────────────────────────────────────────────────────
+
 function formatTimestamp(iso: string): string {
   const d = new Date(iso)
   const now = new Date()
-  const diffMs = now.getTime() - d.getTime()
-  const diffDays = Math.floor(diffMs / 86400000)
+  const diffDays = Math.floor((now.getTime() - d.getTime()) / 86400000)
   if (diffDays === 0) {
     return `today ${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
   }
@@ -17,16 +32,35 @@ function formatTimestamp(iso: string): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
+// ── Component ─────────────────────────────────────────────────────────────────
+
 export default function KaseViewPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+
   const [kase, setKase] = useState<KaseResponse | null>(null)
   const [logList, setLogList] = useState<LogResponse[]>([])
+  const [notFound, setNotFound] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [hoveredId, setHoveredId] = useState<string | null>(null)
 
   useEffect(() => {
     if (!id) return
-    kasesApi.get(id).then(setKase).catch(() => {})
-    logsApi.listByKase(id).then(setLogList).catch(() => {})
+    setLoading(true)
+    setNotFound(false)
+
+    Promise.all([
+      kasesApi.get(id).catch(() => null),
+      logsApi.listByKase(id).catch(() => []),
+    ]).then(([fetchedKase, fetchedLogs]) => {
+      if (fetchedKase === null) {
+        setNotFound(true)
+      } else {
+        setKase(fetchedKase)
+        setLogList(fetchedLogs)
+      }
+      setLoading(false)
+    })
   }, [id])
 
   async function handleNewLog() {
@@ -35,10 +69,51 @@ export default function KaseViewPage() {
       const log = await logsApi.create(id, { title: 'New Log' })
       navigate(`/logs/${log.id}`)
     } catch {
-      // silently ignore
+      // silently ignore — user remains on timeline
     }
   }
 
+  // ── 404 state ───────────────────────────────────────────────────────────────
+  if (!loading && notFound) {
+    return (
+      <>
+        <div style={{
+          height: 48,
+          minHeight: 48,
+          borderBottom: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'center',
+          padding: '0 1.25rem',
+          gap: '0.75rem',
+          flexShrink: 0,
+        }}>
+          <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '-0.02em' }}>
+            Kase not found
+          </div>
+          <div style={{ flex: 1 }} />
+          <Avatar />
+        </div>
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '0.5rem',
+          color: 'var(--text-tertiary)',
+        }}>
+          <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--text-secondary)' }}>
+            This kase doesn&rsquo;t exist
+          </div>
+          <div style={{ fontSize: 13 }}>
+            It may have been deleted or the link is incorrect.
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  // ── Normal render ────────────────────────────────────────────────────────────
   return (
     <>
       {/* Top bar */}
@@ -53,7 +128,7 @@ export default function KaseViewPage() {
         flexShrink: 0,
       }}>
         <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '-0.02em' }}>
-          {kase?.title ?? '…'}
+          {kase?.title ?? '\u2026'}
         </div>
         <div style={{
           fontSize: 11,
@@ -63,7 +138,7 @@ export default function KaseViewPage() {
           borderRadius: 99,
           border: '1px solid var(--border)',
         }}>
-          {kase?.logCount ?? 0} logs
+          {logList.length} {logList.length === 1 ? 'log' : 'logs'}
         </div>
         <div style={{ flex: 1 }} />
         <button
@@ -82,122 +157,227 @@ export default function KaseViewPage() {
         >
           + New Log
         </button>
-        <div style={{
-          width: 30,
-          height: 30,
-          borderRadius: '50%',
-          background: 'var(--accent-light)',
-          border: '1px solid var(--border-mid)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          fontSize: 11,
-          fontWeight: 600,
-          color: 'var(--accent-text)',
-          cursor: 'pointer',
-        }}>
-          K
-        </div>
+        <Avatar />
       </div>
 
       {/* Timeline */}
       <div style={{ flex: 1, overflowY: 'auto', padding: '1.5rem 2rem' }}>
-        {logList.length === 0 ? (
-          <p style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
-            No logs yet. Click &ldquo;+ New Log&rdquo; to get started.
-          </p>
+        {loading ? (
+          <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>Loading&hellip;</div>
+        ) : logList.length === 0 ? (
+          <EmptyState onNewLog={handleNewLog} />
         ) : (
           logList.map((log, i) => (
-            <div
+            <TimelineEntry
               key={log.id}
-              style={{ display: 'flex', gap: '1rem', cursor: 'pointer' }}
+              log={log}
+              index={i}
+              isLast={i === logList.length - 1}
+              isHovered={hoveredId === log.id}
+              onMouseEnter={() => setHoveredId(log.id)}
+              onMouseLeave={() => setHoveredId(null)}
               onClick={() => navigate(`/logs/${log.id}`)}
-            >
-              {/* Spine */}
-              <div style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                paddingTop: 4,
-                width: 14,
-                flexShrink: 0,
-              }}>
-                <div style={{
-                  width: 10,
-                  height: 10,
-                  borderRadius: '50%',
-                  background: i === 0 ? 'var(--accent)' : 'var(--bg-tertiary)',
-                  border: '2px solid var(--bg)',
-                  boxShadow: i === 0
-                    ? '0 0 0 1.5px var(--accent)'
-                    : '0 0 0 1.5px var(--border-mid)',
-                  flexShrink: 0,
-                }} />
-                {i < logList.length - 1 && (
-                  <div style={{
-                    width: 1,
-                    flex: 1,
-                    background: 'var(--border)',
-                    marginTop: 4,
-                    minHeight: '1.25rem',
-                  }} />
-                )}
-              </div>
-
-              {/* Entry body */}
-              <div style={{
-                flex: 1,
-                paddingBottom: '1.25rem',
-                borderBottom: i < logList.length - 1 ? '1px solid var(--border)' : 'none',
-                marginBottom: 0,
-              }}>
-                <div style={{
-                  display: 'flex',
-                  alignItems: 'flex-start',
-                  gap: '0.5rem',
-                  marginBottom: '0.25rem',
-                }}>
-                  <div style={{
-                    fontSize: 13,
-                    fontWeight: 500,
-                    color: 'var(--text-primary)',
-                    flex: 1,
-                    lineHeight: 1.3,
-                  }}>
-                    {log.title}
-                  </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', flexShrink: 0 }}>
-                    <span style={{
-                      fontSize: 10,
-                      color: 'var(--text-tertiary)',
-                      padding: '1px 6px',
-                      background: 'var(--bg-secondary)',
-                      border: '1px solid var(--border)',
-                      borderRadius: 4,
-                      fontFamily: 'var(--font-mono)',
-                    }}>
-                      v{log.versionCount}
-                    </span>
-                    <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>
-                      {formatTimestamp(log.updatedAt)}
-                    </span>
-                  </div>
-                </div>
-                {log.description && (
-                  <div style={{
-                    fontSize: 12,
-                    color: 'var(--text-secondary)',
-                    lineHeight: 1.6,
-                    marginBottom: '0.45rem',
-                  }}>
-                    {log.description}
-                  </div>
-                )}
-              </div>
-            </div>
+            />
           ))
         )}
       </div>
     </>
+  )
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function Avatar() {
+  return (
+    <div style={{
+      width: 30,
+      height: 30,
+      borderRadius: '50%',
+      background: 'var(--accent-light)',
+      border: '1px solid var(--border-mid)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: 11,
+      fontWeight: 600,
+      color: 'var(--accent-text)',
+      cursor: 'pointer',
+      flexShrink: 0,
+    }}>
+      K
+    </div>
+  )
+}
+
+function EmptyState({ onNewLog }: { onNewLog: () => void }) {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingTop: '4rem',
+      gap: '0.75rem',
+    }}>
+      <div style={{ fontSize: 14, color: 'var(--text-secondary)', fontWeight: 500 }}>
+        No logs yet
+      </div>
+      <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
+        Create your first log to start capturing work in this kase
+      </div>
+      <button
+        onClick={onNewLog}
+        style={{
+          marginTop: '0.5rem',
+          fontSize: 13,
+          fontWeight: 500,
+          color: 'var(--bg)',
+          background: 'var(--accent)',
+          padding: '8px 20px',
+          borderRadius: 7,
+          cursor: 'pointer',
+          border: 'none',
+          fontFamily: 'var(--font)',
+        }}
+      >
+        + New Log
+      </button>
+    </div>
+  )
+}
+
+interface TimelineEntryProps {
+  log: LogResponse
+  index: number
+  isLast: boolean
+  isHovered: boolean
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+  onClick: () => void
+}
+
+function TimelineEntry({
+  log,
+  index,
+  isLast,
+  isHovered,
+  onMouseEnter,
+  onMouseLeave,
+  onClick,
+}: TimelineEntryProps) {
+  const isNewest = index === 0
+
+  return (
+    <div
+      style={{ display: 'flex', gap: '1rem', cursor: 'pointer', paddingBottom: '1.25rem' }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+    >
+      {/* Spine */}
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        paddingTop: 4,
+        width: 14,
+        flexShrink: 0,
+      }}>
+        <div style={{
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          background: isNewest ? 'var(--accent)' : 'var(--bg-tertiary)',
+          border: '2px solid var(--bg)',
+          boxShadow: isNewest
+            ? '0 0 0 1.5px var(--accent)'
+            : '0 0 0 1.5px var(--border-mid)',
+          flexShrink: 0,
+        }} />
+        {!isLast && (
+          <div style={{
+            width: 1,
+            flex: 1,
+            background: 'var(--border)',
+            marginTop: 4,
+            minHeight: '1.25rem',
+          }} />
+        )}
+      </div>
+
+      {/* Entry body */}
+      <div style={{
+        flex: 1,
+        paddingBottom: '1.25rem',
+        borderBottom: isLast ? 'none' : '1px solid var(--border)',
+      }}>
+        {/* Header row */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '0.5rem',
+          marginBottom: '0.25rem',
+        }}>
+          <div style={{
+            fontSize: 13,
+            fontWeight: 500,
+            color: isHovered ? 'var(--accent)' : 'var(--text-primary)',
+            flex: 1,
+            lineHeight: 1.3,
+            transition: 'color 0.15s',
+          }}>
+            {log.title}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', flexShrink: 0 }}>
+            <span style={{
+              fontSize: 10,
+              color: 'var(--text-tertiary)',
+              padding: '1px 6px',
+              background: 'var(--bg-secondary)',
+              border: '1px solid var(--border)',
+              borderRadius: 4,
+              fontFamily: 'var(--font-mono)',
+            }}>
+              v{log.versionCount}
+            </span>
+            <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>
+              {formatTimestamp(log.updatedAt)}
+            </span>
+          </div>
+        </div>
+
+        {/* Description */}
+        {log.description && (
+          <div style={{
+            fontSize: 12,
+            color: 'var(--text-secondary)',
+            lineHeight: 1.6,
+            marginBottom: '0.45rem',
+          }}>
+            {log.description}
+          </div>
+        )}
+
+        {/* Tags */}
+        {log.tags.length > 0 && (
+          <div style={{ display: 'flex', gap: '0.3rem', flexWrap: 'wrap' }}>
+            {log.tags.map(tag => (
+              <span
+                key={tag.id}
+                className={`tag-${tagColorClass(tag.name)}`}
+                style={{
+                  fontSize: 10,
+                  padding: '2px 8px',
+                  borderRadius: 99,
+                  fontWeight: 500,
+                }}
+              >
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
   )
 }

--- a/src/kaselog-ui/src/test/KaseViewPage.test.tsx
+++ b/src/kaselog-ui/src/test/KaseViewPage.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import KaseViewPage from '../pages/KaseViewPage'
+import type { KaseResponse, LogResponse, TagResponse } from '../api/types'
+
+// ── Mock the API client ───────────────────────────────────────────────────────
+
+vi.mock('../api/client', () => ({
+  kases: {
+    get: vi.fn(),
+  },
+  logs: {
+    listByKase: vi.fn(),
+    create: vi.fn(),
+  },
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+import { kases as kasesApi, logs as logsApi } from '../api/client'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeKase(overrides: Partial<KaseResponse> = {}): KaseResponse {
+  return {
+    id: 'kase-1',
+    title: 'Proxmox Cluster',
+    description: 'Home lab cluster setup',
+    logCount: 3,
+    createdAt: new Date(Date.now() - 86400000 * 10).toISOString(),
+    updatedAt: new Date(Date.now() - 3600000).toISOString(),
+    ...overrides,
+  }
+}
+
+function makeTag(overrides: Partial<TagResponse> = {}): TagResponse {
+  return {
+    id: 'tag-1',
+    name: 'networking',
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function makeLog(overrides: Partial<LogResponse> = {}): LogResponse {
+  return {
+    id: 'log-1',
+    kaseId: 'kase-1',
+    title: 'VLAN trunk configuration',
+    description: 'Trunk mode on Proxmox nodes.',
+    autosaveEnabled: true,
+    content: '',
+    versionCount: 3,
+    tags: [],
+    createdAt: new Date(Date.now() - 86400000 * 2).toISOString(),
+    updatedAt: new Date(Date.now() - 3600000).toISOString(),
+    ...overrides,
+  }
+}
+
+function renderPage(kaseId = 'kase-1') {
+  return render(
+    <MemoryRouter initialEntries={[`/kases/${kaseId}`]}>
+      <Routes>
+        <Route path="/kases/:id" element={<KaseViewPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('KaseViewPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders timeline entries from mocked data', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase())
+    vi.mocked(logsApi.listByKase).mockResolvedValue([
+      makeLog({ id: 'log-1', title: 'VLAN trunk configuration', versionCount: 3 }),
+      makeLog({ id: 'log-2', title: 'Installed node 3', versionCount: 1 }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('VLAN trunk configuration')).toBeInTheDocument()
+      expect(screen.getByText('Installed node 3')).toBeInTheDocument()
+    })
+  })
+
+  it('shows version badge with correct count', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase())
+    vi.mocked(logsApi.listByKase).mockResolvedValue([
+      makeLog({ id: 'log-1', versionCount: 5 }),
+      makeLog({ id: 'log-2', title: 'Another log', versionCount: 1 }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('v5')).toBeInTheDocument()
+      expect(screen.getByText('v1')).toBeInTheDocument()
+    })
+  })
+
+  it('renders tag pills from log tags', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase())
+    vi.mocked(logsApi.listByKase).mockResolvedValue([
+      makeLog({
+        id: 'log-1',
+        tags: [
+          makeTag({ id: 't1', name: 'networking' }),
+          makeTag({ id: 't2', name: 'proxmox' }),
+        ],
+      }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('networking')).toBeInTheDocument()
+      expect(screen.getByText('proxmox')).toBeInTheDocument()
+    })
+  })
+
+  it('applies consistent color class for the same tag name across entries', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase())
+    vi.mocked(logsApi.listByKase).mockResolvedValue([
+      makeLog({
+        id: 'log-1',
+        tags: [makeTag({ id: 't1', name: 'proxmox' })],
+      }),
+      makeLog({
+        id: 'log-2',
+        title: 'Another log',
+        tags: [makeTag({ id: 't2', name: 'proxmox' })],
+      }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => {
+      const tagPills = screen.getAllByText('proxmox')
+      expect(tagPills).toHaveLength(2)
+      // Both pills must carry the same color class
+      expect(tagPills[0].className).toBe(tagPills[1].className)
+    })
+  })
+
+  it('renders empty state when logs array is empty', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase())
+    vi.mocked(logsApi.listByKase).mockResolvedValue([])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('No logs yet')).toBeInTheDocument()
+    })
+  })
+
+  it('renders 404 state when kase is not found', async () => {
+    vi.mocked(kasesApi.get).mockRejectedValue(new Error('Kase with ID not found'))
+    vi.mocked(logsApi.listByKase).mockResolvedValue([])
+
+    renderPage('nonexistent-id')
+
+    await waitFor(() => {
+      expect(screen.getByText('Kase not found')).toBeInTheDocument()
+    })
+  })
+
+  it('clicking a log entry navigates to /logs/{id}', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase())
+    vi.mocked(logsApi.listByKase).mockResolvedValue([
+      makeLog({ id: 'log-abc', title: 'Click me' }),
+    ])
+    const user = userEvent.setup()
+
+    renderPage()
+
+    await waitFor(() => screen.getByText('Click me'))
+    await user.click(screen.getByText('Click me'))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/logs/log-abc')
+  })
+
+  it('New Log button calls POST and navigates to /logs/{id}', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase())
+    vi.mocked(logsApi.listByKase).mockResolvedValue([])
+    vi.mocked(logsApi.create).mockResolvedValue(makeLog({ id: 'new-log-id' }))
+    const user = userEvent.setup()
+
+    renderPage()
+
+    await waitFor(() => screen.getByText('No logs yet'))
+
+    // There is a New Log button in the top bar and one inside the empty state
+    const newLogBtn = screen.getAllByRole('button', { name: /\+ New Log/i })[0]
+    await user.click(newLogBtn)
+
+    await waitFor(() => {
+      expect(logsApi.create).toHaveBeenCalledWith('kase-1', { title: 'New Log' })
+      expect(mockNavigate).toHaveBeenCalledWith('/logs/new-log-id')
+    })
+  })
+
+  it('shows the kase title and log count in the top bar', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase({ title: 'My Kase', logCount: 7 }))
+    vi.mocked(logsApi.listByKase).mockResolvedValue([
+      makeLog({ id: 'l1', title: 'Log A' }),
+      makeLog({ id: 'l2', title: 'Log B' }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('My Kase')).toBeInTheDocument()
+      expect(screen.getByText('2 logs')).toBeInTheDocument()
+    })
+  })
+
+  it('renders log descriptions when present', async () => {
+    vi.mocked(kasesApi.get).mockResolvedValue(makeKase())
+    vi.mocked(logsApi.listByKase).mockResolvedValue([
+      makeLog({ id: 'log-1', description: 'Some meaningful description text' }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Some meaningful description text')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Backend:** `LogResponse` now includes `Tags: IReadOnlyList<TagDto>`. `SqliteLogRepository` fetches tags for all logs in a single `JOIN` query (one round-trip for `GetByKaseIdAsync`) and attaches them per log. No API surface changes.
- **Frontend types:** Added `TagResponse` interface; `LogResponse.tags` is now `TagResponse[]`.
- **KaseViewPage:** Full rewrite matching `kaselog-timeline.html` — timeline spine + accent dot for newest entry, version badges (`v{N}` monospaced), relative timestamps, description previews, tag pills with deterministic hash-based color palette (same tag name → same color across all views), hover state on entry titles (color → `--accent`), 404 state for missing kases, loading state, empty state with "+ New Log" CTA.

## Test plan

- [x] `KaseViewPage.test.tsx` — 10 new tests: timeline entries render, version badge count, tag pills present, consistent tag colors for same name, empty state, 404 state, click navigation to `/logs/{id}`, New Log POST + navigate, top bar content, description preview
- [x] All 16 frontend tests pass (`npm test`)
- [x] All 37 backend tests pass (`dotnet test` via Docker)
- [x] `docker build` succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)