### PR TITLE
feat: theme and accent system with localStorage persistence

### DIFF
--- a/src/kaselog-ui/index.html
+++ b/src/kaselog-ui/index.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KaseLog</title>
+    <!-- Apply stored theme/accent before first render to prevent flash -->
+    <script>
+      (function () {
+        var ACCENT_COLORS = {
+          teal: '#1D9E75', blue: '#378ADD', purple: '#7F77DD',
+          coral: '#D85A30', amber: '#BA7517',
+        }
+        try {
+          var p = JSON.parse(localStorage.getItem('kaselog-prefs') || '{}')
+          if (p.theme === 'dark') document.documentElement.setAttribute('data-theme', 'dark')
+          if (p.accent && ACCENT_COLORS[p.accent]) {
+            document.documentElement.style.setProperty('--accent', ACCENT_COLORS[p.accent])
+            if (p.accent !== 'teal') document.documentElement.setAttribute('data-accent', p.accent)
+          }
+        } catch (e) {}
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/kaselog-ui/src/components/AppearancePanel.tsx
+++ b/src/kaselog-ui/src/components/AppearancePanel.tsx
@@ -1,0 +1,157 @@
+import { useTheme, ACCENT_DEFS } from '../contexts/ThemeContext'
+
+interface Props {
+  onClose: () => void
+}
+
+export default function AppearancePanel({ onClose }: Props) {
+  const { theme, accent, setTheme, setAccent } = useTheme()
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          zIndex: 40,
+        }}
+      />
+
+      {/* Panel */}
+      <div
+        data-testid="appearance-panel"
+        style={{
+          position: 'fixed',
+          bottom: 80,
+          left: 12,
+          width: 220,
+          background: 'var(--bg)',
+          border: '1px solid var(--border-mid)',
+          borderRadius: 10,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+          zIndex: 50,
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          padding: '0.65rem 0.9rem',
+          borderBottom: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}>
+          <div>
+            <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-primary)' }}>Appearance</div>
+            <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 1 }}>Theme and accent color</div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close appearance panel"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: 14,
+              color: 'var(--text-tertiary)',
+              padding: '2px 4px',
+              fontFamily: 'var(--font)',
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: '0.85rem 0.9rem', display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
+
+          {/* Theme row */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <div style={{ fontSize: 12, color: 'var(--text-secondary)', minWidth: 52 }}>Theme</div>
+            <div style={{ display: 'flex', gap: '0.4rem' }}>
+              <button
+                aria-label="Light theme"
+                data-testid="theme-light-btn"
+                onClick={() => setTheme('light')}
+                style={{
+                  width: 36,
+                  height: 24,
+                  borderRadius: 6,
+                  border: `2px solid ${theme === 'light' ? 'var(--accent)' : 'var(--border)'}`,
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 11,
+                  fontWeight: 500,
+                  color: theme === 'light' ? 'var(--accent)' : 'var(--text-tertiary)',
+                  background: '#f7f6f3',
+                  fontFamily: 'var(--font)',
+                  transition: 'all 0.15s',
+                }}
+              >
+                ☀
+              </button>
+              <button
+                aria-label="Dark theme"
+                data-testid="theme-dark-btn"
+                onClick={() => setTheme('dark')}
+                style={{
+                  width: 36,
+                  height: 24,
+                  borderRadius: 6,
+                  border: `2px solid ${theme === 'dark' ? 'var(--accent)' : 'var(--border)'}`,
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 11,
+                  fontWeight: 500,
+                  color: theme === 'dark' ? 'var(--accent)' : 'var(--text-tertiary)',
+                  background: '#1c1c1a',
+                  fontFamily: 'var(--font)',
+                  transition: 'all 0.15s',
+                }}
+              >
+                ☽
+              </button>
+            </div>
+          </div>
+
+          {/* Accent row */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <div style={{ fontSize: 12, color: 'var(--text-secondary)', minWidth: 52 }}>Accent</div>
+            <div style={{ display: 'flex', gap: '0.45rem' }}>
+              {ACCENT_DEFS.map(def => (
+                <button
+                  key={def.name}
+                  aria-label={`${def.label} accent`}
+                  data-testid={`accent-${def.name}`}
+                  onClick={() => setAccent(def.name)}
+                  style={{
+                    width: 22,
+                    height: 22,
+                    borderRadius: '50%',
+                    background: def.value,
+                    border: accent === def.name
+                      ? `2px solid ${def.value}`
+                      : '2px solid transparent',
+                    cursor: 'pointer',
+                    outline: accent === def.name ? `2px solid ${def.value}` : 'none',
+                    outlineOffset: 2,
+                    padding: 0,
+                    transition: 'all 0.15s',
+                  }}
+                  title={def.label}
+                />
+              ))}
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/kaselog-ui/src/components/LeftNav.tsx
+++ b/src/kaselog-ui/src/components/LeftNav.tsx
@@ -3,9 +3,10 @@ import { useKases } from '../contexts/KasesContext'
 
 interface LeftNavProps {
   onSearchOpen: () => void
+  onAppearanceOpen: () => void
 }
 
-export default function LeftNav({ onSearchOpen }: LeftNavProps) {
+export default function LeftNav({ onSearchOpen, onAppearanceOpen }: LeftNavProps) {
   const { kaseList } = useKases()
   const navigate = useNavigate()
   const kaseMatch = useMatch('/kases/:id')
@@ -102,8 +103,43 @@ export default function LeftNav({ onSearchOpen }: LeftNavProps) {
         })}
       </div>
 
-      {/* Search — pinned */}
-      <div style={{ borderTop: '1px solid var(--border)', padding: '0.6rem', background: 'var(--bg-secondary)' }}>
+      {/* Avatar + Search — pinned */}
+      <div style={{ borderTop: '1px solid var(--border)', padding: '0.5rem 0.6rem 0.6rem', background: 'var(--bg-secondary)', display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+        <button
+          onClick={onAppearanceOpen}
+          aria-label="Open appearance settings"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            padding: '0.4rem 0.65rem',
+            borderRadius: 7,
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            width: '100%',
+            fontFamily: 'var(--font)',
+          }}
+        >
+          <div style={{
+            width: 24,
+            height: 24,
+            borderRadius: '50%',
+            background: 'var(--accent)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 11,
+            fontWeight: 600,
+            color: 'white',
+            flexShrink: 0,
+          }}>
+            U
+          </div>
+          <span style={{ fontSize: 12, color: 'var(--text-secondary)', flex: 1, textAlign: 'left' }}>
+            Appearance
+          </span>
+        </button>
         <button
           onClick={onSearchOpen}
           style={{

--- a/src/kaselog-ui/src/components/Shell.tsx
+++ b/src/kaselog-ui/src/components/Shell.tsx
@@ -2,26 +2,35 @@ import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import LeftNav from './LeftNav'
 import SearchOverlay from './SearchOverlay'
+import AppearancePanel from './AppearancePanel'
 import { KasesProvider } from '../contexts/KasesContext'
+import { ThemeProvider } from '../contexts/ThemeContext'
 
 export default function Shell() {
   const [overlayOpen, setOverlayOpen] = useState(false)
+  const [appearanceOpen, setAppearanceOpen] = useState(false)
 
   return (
-    <KasesProvider>
-      <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-        <LeftNav onSearchOpen={() => setOverlayOpen(true)} />
-        <main style={{
-          flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          background: 'var(--bg)',
-        }}>
-          <Outlet />
-        </main>
-      </div>
-      {overlayOpen && <SearchOverlay onClose={() => setOverlayOpen(false)} />}
-    </KasesProvider>
+    <ThemeProvider>
+      <KasesProvider>
+        <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+          <LeftNav
+            onSearchOpen={() => setOverlayOpen(true)}
+            onAppearanceOpen={() => setAppearanceOpen(true)}
+          />
+          <main style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            background: 'var(--bg)',
+          }}>
+            <Outlet />
+          </main>
+        </div>
+        {overlayOpen && <SearchOverlay onClose={() => setOverlayOpen(false)} />}
+        {appearanceOpen && <AppearancePanel onClose={() => setAppearanceOpen(false)} />}
+      </KasesProvider>
+    </ThemeProvider>
   )
 }

--- a/src/kaselog-ui/src/contexts/ThemeContext.tsx
+++ b/src/kaselog-ui/src/contexts/ThemeContext.tsx
@@ -1,0 +1,119 @@
+import { createContext, useContext, useState } from 'react'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type Theme = 'light' | 'dark'
+export type Accent = 'teal' | 'blue' | 'purple' | 'coral' | 'amber'
+
+export interface AccentDef {
+  name: Accent
+  label: string
+  value: string
+}
+
+export const ACCENT_DEFS: AccentDef[] = [
+  { name: 'teal',   label: 'Teal',   value: '#1D9E75' },
+  { name: 'blue',   label: 'Blue',   value: '#378ADD' },
+  { name: 'purple', label: 'Purple', value: '#7F77DD' },
+  { name: 'coral',  label: 'Coral',  value: '#D85A30' },
+  { name: 'amber',  label: 'Amber',  value: '#BA7517' },
+]
+
+const ACCENT_NAMES = ACCENT_DEFS.map(a => a.name) as Accent[]
+
+// ── Storage ────────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'kaselog-prefs'
+
+interface StoredPrefs {
+  theme: Theme
+  accent: Accent
+}
+
+function loadPrefs(): StoredPrefs {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const p = JSON.parse(raw) as Record<string, unknown>
+      return {
+        theme:  p['theme'] === 'dark' ? 'dark' : 'light',
+        accent: ACCENT_NAMES.includes(p['accent'] as Accent) ? (p['accent'] as Accent) : 'teal',
+      }
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return { theme: 'light', accent: 'teal' }
+}
+
+function savePrefs(prefs: StoredPrefs) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs))
+  } catch {
+    // ignore storage errors
+  }
+}
+
+// ── DOM application ────────────────────────────────────────────────────────
+
+export function applyThemeToDOM(theme: Theme) {
+  document.body.setAttribute('data-theme', theme)
+}
+
+export function applyAccentToDOM(accent: Accent) {
+  const def = ACCENT_DEFS.find(a => a.name === accent)!
+  // Set --accent on :root (html element) as inline style for immediate effect
+  document.documentElement.style.setProperty('--accent', def.value)
+  // Set data-accent so CSS handles --accent-light / --accent-text variants
+  if (accent === 'teal') {
+    document.body.removeAttribute('data-accent')
+  } else {
+    document.body.setAttribute('data-accent', accent)
+  }
+}
+
+// ── Context ────────────────────────────────────────────────────────────────
+
+interface ThemeContextValue {
+  theme: Theme
+  accent: Accent
+  setTheme: (t: Theme) => void
+  setAccent: (a: Accent) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [prefs, setPrefs] = useState<StoredPrefs>(() => {
+    const p = loadPrefs()
+    applyThemeToDOM(p.theme)
+    applyAccentToDOM(p.accent)
+    return p
+  })
+
+  function setTheme(theme: Theme) {
+    const next = { ...prefs, theme }
+    applyThemeToDOM(theme)
+    savePrefs(next)
+    setPrefs(next)
+  }
+
+  function setAccent(accent: Accent) {
+    const next = { ...prefs, accent }
+    applyAccentToDOM(accent)
+    savePrefs(next)
+    setPrefs(next)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme: prefs.theme, accent: prefs.accent, setTheme, setAccent }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/src/kaselog-ui/src/test/ThemeAccent.test.tsx
+++ b/src/kaselog-ui/src/test/ThemeAccent.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '../contexts/ThemeContext'
+import AppearancePanel from '../components/AppearancePanel'
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function renderPanel() {
+  return render(
+    <ThemeProvider>
+      <AppearancePanel onClose={() => {}} />
+    </ThemeProvider>,
+  )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('Theme and accent system', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.body.removeAttribute('data-theme')
+    document.body.removeAttribute('data-accent')
+    document.documentElement.style.removeProperty('--accent')
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    document.body.removeAttribute('data-theme')
+    document.body.removeAttribute('data-accent')
+    document.documentElement.style.removeProperty('--accent')
+  })
+
+  it('default theme is light when no localStorage value exists', () => {
+    renderPanel()
+    // body should have data-theme='light' (or not 'dark')
+    const t = document.body.getAttribute('data-theme')
+    expect(t === null || t === 'light').toBe(true)
+  })
+
+  it('clicking Dark applies data-theme="dark" to body', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByTestId('theme-dark-btn'))
+
+    expect(document.body.getAttribute('data-theme')).toBe('dark')
+  })
+
+  it('clicking Light applies data-theme="light" to body', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    // Start from dark
+    await user.click(screen.getByTestId('theme-dark-btn'))
+    expect(document.body.getAttribute('data-theme')).toBe('dark')
+
+    // Switch back to light
+    await user.click(screen.getByTestId('theme-light-btn'))
+    expect(document.body.getAttribute('data-theme')).toBe('light')
+  })
+
+  it('clicking an accent updates --accent on :root', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByTestId('accent-blue'))
+
+    expect(document.documentElement.style.getPropertyValue('--accent')).toBe('#378ADD')
+  })
+
+  it('preferences written to localStorage on change', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+
+    await user.click(screen.getByTestId('theme-dark-btn'))
+    await user.click(screen.getByTestId('accent-purple'))
+
+    const stored = JSON.parse(localStorage.getItem('kaselog-prefs') ?? '{}')
+    expect(stored.theme).toBe('dark')
+    expect(stored.accent).toBe('purple')
+  })
+
+  it('stored preferences correctly restored on simulated reload', () => {
+    // Pre-seed localStorage as if a previous session saved dark + amber
+    localStorage.setItem('kaselog-prefs', JSON.stringify({ theme: 'dark', accent: 'amber' }))
+
+    renderPanel()
+
+    expect(document.body.getAttribute('data-theme')).toBe('dark')
+    expect(document.documentElement.style.getPropertyValue('--accent')).toBe('#BA7517')
+  })
+})


### PR DESCRIPTION
## Summary
- `ThemeContext`: light/dark theme + 5 accent presets (teal, blue, purple, coral, amber); persists to `localStorage`; applies `data-theme` to `document.body` and `--accent` inline on `:root`
- `AppearancePanel`: theme toggle buttons (☀ / ☽) and accent circle selector matching `kaselog-settings.html` reference
- `Shell`: wraps app in `ThemeProvider`, wires avatar button → `AppearancePanel`
- `LeftNav`: adds avatar/appearance button pinned above search
- `index.html`: inline init script reads `kaselog-prefs` from localStorage and applies theme + accent before React renders (prevents flash)

## Test plan
- [ ] All 59 tests pass (`npm test`)
- [ ] Default theme is light with no localStorage value
- [ ] Clicking Dark → `data-theme="dark"` on body
- [ ] Clicking Light → `data-theme="light"` on body
- [ ] Clicking accent → `--accent` updated on `:root`
- [ ] Changes written to `localStorage`
- [ ] Stored prefs restored on simulated reload
- [ ] Theme and accent persist across page reloads in the running container

🤖 Generated with [Claude Code](https://claude.com/claude-code)