### PR TITLE
feat: theme/accent system and user profile panel

### DIFF
--- a/src/KaseLog.Api/Controllers/UserController.cs
+++ b/src/KaseLog.Api/Controllers/UserController.cs
@@ -1,0 +1,38 @@
+using KaseLog.Api.Data;
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KaseLog.Api.Controllers;
+
+/// <summary>User profile — read and update the local user account.</summary>
+[ApiController]
+[Route("api/user")]
+[Produces("application/json")]
+public sealed class UserController : ControllerBase
+{
+    private readonly IUserRepository _users;
+
+    /// <summary>Initialises a new instance of <see cref="UserController"/>.</summary>
+    public UserController(IUserRepository users) => _users = users;
+
+    /// <summary>Returns the current user profile.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<UserResponse>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Get()
+    {
+        var user = await _users.GetAsync();
+        return Ok(ApiResponse<UserResponse>.Success(user));
+    }
+
+    /// <summary>Creates or updates the user profile.</summary>
+    /// <param name="request">Profile fields and appearance preferences.</param>
+    [HttpPut]
+    [ProducesResponseType(typeof(ApiResponse<UserResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<UserResponse>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Update([FromBody] UpdateUserRequest request)
+    {
+        var user = await _users.UpsertAsync(request);
+        return Ok(ApiResponse<UserResponse>.Success(user));
+    }
+}

--- a/src/KaseLog.Api/Data/IUserRepository.cs
+++ b/src/KaseLog.Api/Data/IUserRepository.cs
@@ -1,0 +1,10 @@
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+
+namespace KaseLog.Api.Data;
+
+public interface IUserRepository
+{
+    Task<UserResponse> GetAsync();
+    Task<UserResponse> UpsertAsync(UpdateUserRequest request);
+}

--- a/src/KaseLog.Api/Data/Sqlite/SqliteSchemaInitializer.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteSchemaInitializer.cs
@@ -86,6 +86,21 @@ public sealed class SqliteSchemaInitializer : ISchemaInitializer
         )
         """,
 
+        // ── Users ────────────────────────────────────────────────────────────
+        // Single-user table. Always one row identified by a well-known ID.
+        """
+        CREATE TABLE IF NOT EXISTS Users (
+          Id        TEXT PRIMARY KEY,
+          FirstName TEXT,
+          LastName  TEXT,
+          Email     TEXT,
+          Theme     TEXT NOT NULL DEFAULT 'light',
+          Accent    TEXT NOT NULL DEFAULT 'teal',
+          CreatedAt TEXT NOT NULL,
+          UpdatedAt TEXT NOT NULL
+        )
+        """,
+
         // ── FTS5 sync triggers ───────────────────────────────────────────────
         // One FTS row per Log, always reflecting the most recent LogVersion.
         // INSERT: replace existing FTS entry with the new version's content.

--- a/src/KaseLog.Api/Data/Sqlite/SqliteUserRepository.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteUserRepository.cs
@@ -1,0 +1,106 @@
+using Dapper;
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+
+namespace KaseLog.Api.Data.Sqlite;
+
+public sealed class SqliteUserRepository : IUserRepository
+{
+    // Single well-known ID for the local user profile.
+    private const string LocalUserId = "00000000-0000-0000-0000-000000000001";
+
+    private readonly IDbConnectionFactory _factory;
+
+    public SqliteUserRepository(IDbConnectionFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task<UserResponse> GetAsync()
+    {
+        using var connection = await _factory.OpenAsync();
+
+        var row = await connection.QuerySingleOrDefaultAsync<UserRow>(
+            "SELECT Id, FirstName, LastName, Email, Theme, Accent, CreatedAt, UpdatedAt FROM Users WHERE Id = @Id",
+            new { Id = LocalUserId });
+
+        if (row is null)
+        {
+            // Return defaults — the row is created on first PUT.
+            var now = DateTime.UtcNow.ToString("o");
+            return new UserResponse
+            {
+                Id        = LocalUserId,
+                FirstName = null,
+                LastName  = null,
+                Email     = null,
+                Theme     = "light",
+                Accent    = "teal",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+        }
+
+        return Map(row);
+    }
+
+    public async Task<UserResponse> UpsertAsync(UpdateUserRequest request)
+    {
+        using var connection = await _factory.OpenAsync();
+
+        var now = DateTime.UtcNow.ToString("o");
+
+        await connection.ExecuteAsync(
+            """
+            INSERT INTO Users (Id, FirstName, LastName, Email, Theme, Accent, CreatedAt, UpdatedAt)
+            VALUES (@Id, @FirstName, @LastName, @Email, @Theme, @Accent, @Now, @Now)
+            ON CONFLICT(Id) DO UPDATE SET
+              FirstName = excluded.FirstName,
+              LastName  = excluded.LastName,
+              Email     = excluded.Email,
+              Theme     = excluded.Theme,
+              Accent    = excluded.Accent,
+              UpdatedAt = excluded.UpdatedAt
+            """,
+            new
+            {
+                Id        = LocalUserId,
+                request.FirstName,
+                request.LastName,
+                request.Email,
+                request.Theme,
+                request.Accent,
+                Now       = now,
+            });
+
+        var row = await connection.QuerySingleAsync<UserRow>(
+            "SELECT Id, FirstName, LastName, Email, Theme, Accent, CreatedAt, UpdatedAt FROM Users WHERE Id = @Id",
+            new { Id = LocalUserId });
+
+        return Map(row);
+    }
+
+    private static UserResponse Map(UserRow row) => new()
+    {
+        Id        = row.Id,
+        FirstName = row.FirstName,
+        LastName  = row.LastName,
+        Email     = row.Email,
+        Theme     = row.Theme,
+        Accent    = row.Accent,
+        CreatedAt = row.CreatedAt,
+        UpdatedAt = row.UpdatedAt,
+    };
+
+    private sealed class UserRow
+    {
+        public required string Id { get; init; }
+        public string? FirstName { get; init; }
+        public string? LastName { get; init; }
+        public string? Email { get; init; }
+        public required string Theme { get; init; }
+        public required string Accent { get; init; }
+        public required string CreatedAt { get; init; }
+        public required string UpdatedAt { get; init; }
+    }
+}

--- a/src/KaseLog.Api/Models/Requests/UpdateUserRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/UpdateUserRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class UpdateUserRequest
+{
+    public string? FirstName { get; init; }
+    public string? LastName { get; init; }
+    public string? Email { get; init; }
+
+    [Required]
+    public required string Theme { get; init; }
+
+    [Required]
+    public required string Accent { get; init; }
+}

--- a/src/KaseLog.Api/Models/UserResponse.cs
+++ b/src/KaseLog.Api/Models/UserResponse.cs
@@ -1,0 +1,13 @@
+namespace KaseLog.Api.Models;
+
+public sealed class UserResponse
+{
+    public required string Id { get; init; }
+    public string? FirstName { get; init; }
+    public string? LastName { get; init; }
+    public string? Email { get; init; }
+    public required string Theme { get; init; }
+    public required string Accent { get; init; }
+    public required string CreatedAt { get; init; }
+    public required string UpdatedAt { get; init; }
+}

--- a/src/KaseLog.Api/Program.cs
+++ b/src/KaseLog.Api/Program.cs
@@ -32,6 +32,7 @@ if (dbProvider.Equals("sqlite", StringComparison.OrdinalIgnoreCase))
     builder.Services.AddScoped<ILogRepository, SqliteLogRepository>();
     builder.Services.AddScoped<ITagRepository, SqliteTagRepository>();
     builder.Services.AddScoped<ISearchRepository, SqliteSearchRepository>();
+    builder.Services.AddScoped<IUserRepository, SqliteUserRepository>();
 }
 else
 {

--- a/src/kaselog-ui/src/api/client.ts
+++ b/src/kaselog-ui/src/api/client.ts
@@ -5,11 +5,13 @@ import type {
   LogVersionResponse,
   TagResponse,
   SearchResult,
+  UserResponse,
   CreateKaseRequest,
   UpdateKaseRequest,
   CreateLogRequest,
   UpdateLogRequest,
   CreateVersionRequest,
+  UpdateUserRequest,
 } from './types'
 
 // ── Base request helper ───────────────────────────────────────────────────────
@@ -128,6 +130,19 @@ export const images = {
     }
     return envelope.data as { uid: string; url: string }
   },
+}
+
+// ── User ──────────────────────────────────────────────────────────────────────
+
+export const user = {
+  get: (): Promise<UserResponse> =>
+    request<UserResponse>('/api/user'),
+
+  update: (body: UpdateUserRequest): Promise<UserResponse> =>
+    request<UserResponse>('/api/user', {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }),
 }
 
 // ── Search ────────────────────────────────────────────────────────────────────

--- a/src/kaselog-ui/src/api/types.ts
+++ b/src/kaselog-ui/src/api/types.ts
@@ -63,6 +63,17 @@ export interface SearchResult {
   updatedAt: string
 }
 
+export interface UserResponse {
+  id: string
+  firstName: string | null
+  lastName: string | null
+  email: string | null
+  theme: string
+  accent: string
+  createdAt: string
+  updatedAt: string
+}
+
 // ── Request bodies ────────────────────────────────────────────────────────────
 
 export interface CreateKaseRequest {
@@ -85,6 +96,14 @@ export interface UpdateLogRequest {
   title: string
   description?: string | null
   autosaveEnabled?: boolean
+}
+
+export interface UpdateUserRequest {
+  firstName?: string | null
+  lastName?: string | null
+  email?: string | null
+  theme: string
+  accent: string
 }
 
 export interface CreateVersionRequest {

--- a/src/kaselog-ui/src/components/LeftNav.tsx
+++ b/src/kaselog-ui/src/components/LeftNav.tsx
@@ -1,16 +1,27 @@
 import { useMatch, useNavigate } from 'react-router-dom'
 import { useKases } from '../contexts/KasesContext'
+import { useUser } from '../contexts/UserContext'
 
 interface LeftNavProps {
   onSearchOpen: () => void
-  onAppearanceOpen: () => void
+  onProfileOpen: () => void
 }
 
-export default function LeftNav({ onSearchOpen, onAppearanceOpen }: LeftNavProps) {
+function getInitials(firstName: string | null | undefined, lastName: string | null | undefined): string {
+  const f = firstName?.trim()[0]?.toUpperCase() ?? ''
+  const l = lastName?.trim()[0]?.toUpperCase() ?? ''
+  return f || l ? `${f}${l}` : 'U'
+}
+
+export default function LeftNav({ onSearchOpen, onProfileOpen }: LeftNavProps) {
   const { kaseList } = useKases()
+  const { user } = useUser()
   const navigate = useNavigate()
   const kaseMatch = useMatch('/kases/:id')
   const activeKaseId = kaseMatch?.params.id
+
+  const initials = getInitials(user?.firstName, user?.lastName)
+  const displayName = [user?.firstName, user?.lastName].filter(Boolean).join(' ') || 'Profile'
 
   return (
     <nav style={{
@@ -106,8 +117,8 @@ export default function LeftNav({ onSearchOpen, onAppearanceOpen }: LeftNavProps
       {/* Avatar + Search — pinned */}
       <div style={{ borderTop: '1px solid var(--border)', padding: '0.5rem 0.6rem 0.6rem', background: 'var(--bg-secondary)', display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
         <button
-          onClick={onAppearanceOpen}
-          aria-label="Open appearance settings"
+          onClick={onProfileOpen}
+          aria-label="Open user profile"
           style={{
             display: 'flex',
             alignItems: 'center',
@@ -129,15 +140,16 @@ export default function LeftNav({ onSearchOpen, onAppearanceOpen }: LeftNavProps
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            fontSize: 11,
+            fontSize: 10,
             fontWeight: 600,
             color: 'white',
             flexShrink: 0,
+            letterSpacing: '-0.02em',
           }}>
-            U
+            {initials}
           </div>
-          <span style={{ fontSize: 12, color: 'var(--text-secondary)', flex: 1, textAlign: 'left' }}>
-            Appearance
+          <span style={{ fontSize: 12, color: 'var(--text-secondary)', flex: 1, textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {displayName}
           </span>
         </button>
         <button

--- a/src/kaselog-ui/src/components/Shell.tsx
+++ b/src/kaselog-ui/src/components/Shell.tsx
@@ -2,35 +2,38 @@ import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import LeftNav from './LeftNav'
 import SearchOverlay from './SearchOverlay'
-import AppearancePanel from './AppearancePanel'
+import UserProfilePanel from './UserProfilePanel'
 import { KasesProvider } from '../contexts/KasesContext'
 import { ThemeProvider } from '../contexts/ThemeContext'
+import { UserProvider } from '../contexts/UserContext'
 
 export default function Shell() {
   const [overlayOpen, setOverlayOpen] = useState(false)
-  const [appearanceOpen, setAppearanceOpen] = useState(false)
+  const [profileOpen, setProfileOpen] = useState(false)
 
   return (
     <ThemeProvider>
-      <KasesProvider>
-        <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-          <LeftNav
-            onSearchOpen={() => setOverlayOpen(true)}
-            onAppearanceOpen={() => setAppearanceOpen(true)}
-          />
-          <main style={{
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            overflow: 'hidden',
-            background: 'var(--bg)',
-          }}>
-            <Outlet />
-          </main>
-        </div>
-        {overlayOpen && <SearchOverlay onClose={() => setOverlayOpen(false)} />}
-        {appearanceOpen && <AppearancePanel onClose={() => setAppearanceOpen(false)} />}
-      </KasesProvider>
+      <UserProvider>
+        <KasesProvider>
+          <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+            <LeftNav
+              onSearchOpen={() => setOverlayOpen(true)}
+              onProfileOpen={() => setProfileOpen(true)}
+            />
+            <main style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              background: 'var(--bg)',
+            }}>
+              <Outlet />
+            </main>
+          </div>
+          {overlayOpen && <SearchOverlay onClose={() => setOverlayOpen(false)} />}
+          {profileOpen && <UserProfilePanel onClose={() => setProfileOpen(false)} />}
+        </KasesProvider>
+      </UserProvider>
     </ThemeProvider>
   )
 }

--- a/src/kaselog-ui/src/components/UserProfilePanel.tsx
+++ b/src/kaselog-ui/src/components/UserProfilePanel.tsx
@@ -1,0 +1,273 @@
+import { useState, useEffect, useRef } from 'react'
+import { useTheme, ACCENT_DEFS } from '../contexts/ThemeContext'
+import { useUser } from '../contexts/UserContext'
+
+interface Props {
+  onClose: () => void
+}
+
+export default function UserProfilePanel({ onClose }: Props) {
+  const { theme, accent, setTheme, setAccent } = useTheme()
+  const { user, saveProfile, saveAppearance } = useUser()
+
+  const [firstName, setFirstName] = useState(user?.firstName ?? '')
+  const [lastName, setLastName] = useState(user?.lastName ?? '')
+  const [email, setEmail] = useState(user?.email ?? '')
+  const initialized = useRef(false)
+
+  // Sync fields once user data arrives from the backend (async load)
+  useEffect(() => {
+    if (user && !initialized.current) {
+      initialized.current = true
+      setFirstName(user.firstName ?? '')
+      setLastName(user.lastName ?? '')
+      setEmail(user.email ?? '')
+    }
+  }, [user])
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  async function handleSaveProfile() {
+    setSaving(true)
+    try {
+      await saveProfile({
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        email: email.trim(),
+      })
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleTheme(t: 'light' | 'dark') {
+    setTheme(t)
+    saveAppearance(t, accent).catch(() => {/* best-effort */})
+  }
+
+  function handleAccent(a: typeof accent) {
+    setAccent(a)
+    saveAppearance(theme, a).catch(() => {/* best-effort */})
+  }
+
+  const inputStyle: React.CSSProperties = {
+    background: 'var(--bg-secondary)',
+    border: '1px solid var(--border-mid)',
+    borderRadius: 6,
+    padding: '0.4rem 0.6rem',
+    fontSize: 12,
+    color: 'var(--text-primary)',
+    fontFamily: 'var(--font)',
+    width: '100%',
+    outline: 'none',
+  }
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 10,
+    fontWeight: 600,
+    color: 'var(--text-tertiary)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.07em',
+    marginBottom: '0.3rem',
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{ position: 'fixed', inset: 0, zIndex: 40 }}
+      />
+
+      {/* Panel */}
+      <div
+        data-testid="user-profile-panel"
+        style={{
+          position: 'fixed',
+          bottom: 80,
+          left: 12,
+          width: 268,
+          background: 'var(--bg)',
+          border: '1px solid var(--border-mid)',
+          borderRadius: 10,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+          zIndex: 50,
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          padding: '0.65rem 0.9rem',
+          borderBottom: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}>
+          <div>
+            <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--text-primary)' }}>Profile</div>
+            <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 1 }}>Account details and appearance</div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close profile panel"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: 14,
+              color: 'var(--text-tertiary)',
+              padding: '2px 4px',
+              fontFamily: 'var(--font)',
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Profile section */}
+        <div style={{ padding: '0.85rem 0.9rem', display: 'flex', flexDirection: 'column', gap: '0.65rem' }}>
+
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <div style={{ flex: 1 }}>
+              <div style={labelStyle}>First name</div>
+              <input
+                data-testid="profile-first-name"
+                value={firstName}
+                onChange={e => setFirstName(e.target.value)}
+                placeholder="First"
+                style={inputStyle}
+              />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={labelStyle}>Last name</div>
+              <input
+                data-testid="profile-last-name"
+                value={lastName}
+                onChange={e => setLastName(e.target.value)}
+                placeholder="Last"
+                style={inputStyle}
+              />
+            </div>
+          </div>
+
+          <div>
+            <div style={labelStyle}>Email</div>
+            <input
+              data-testid="profile-email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              style={inputStyle}
+            />
+          </div>
+
+          <button
+            data-testid="profile-save-btn"
+            onClick={handleSaveProfile}
+            disabled={saving}
+            style={{
+              padding: '0.45rem 0.75rem',
+              background: 'var(--accent)',
+              color: 'white',
+              border: 'none',
+              borderRadius: 6,
+              fontSize: 12,
+              fontWeight: 500,
+              cursor: saving ? 'default' : 'pointer',
+              fontFamily: 'var(--font)',
+              opacity: saving ? 0.7 : 1,
+              transition: 'opacity 0.15s',
+            }}
+          >
+            {saved ? 'Saved!' : saving ? 'Saving...' : 'Save changes'}
+          </button>
+
+        </div>
+
+        {/* Divider */}
+        <div style={{ borderTop: '1px solid var(--border)' }} />
+
+        {/* Appearance section */}
+        <div style={{ padding: '0.85rem 0.9rem', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+
+          <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.07em' }}>
+            Appearance
+          </div>
+
+          {/* Theme row */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <div style={{ fontSize: 12, color: 'var(--text-secondary)', minWidth: 52 }}>Theme</div>
+            <div style={{ display: 'flex', gap: '0.4rem' }}>
+              <button
+                aria-label="Light theme"
+                data-testid="theme-light-btn"
+                onClick={() => handleTheme('light')}
+                style={{
+                  width: 36, height: 24, borderRadius: 6,
+                  border: `2px solid ${theme === 'light' ? 'var(--accent)' : 'var(--border)'}`,
+                  cursor: 'pointer',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 11, fontWeight: 500,
+                  color: theme === 'light' ? 'var(--accent)' : 'var(--text-tertiary)',
+                  background: '#f7f6f3',
+                  fontFamily: 'var(--font)',
+                  transition: 'all 0.15s',
+                }}
+              >
+                ☀
+              </button>
+              <button
+                aria-label="Dark theme"
+                data-testid="theme-dark-btn"
+                onClick={() => handleTheme('dark')}
+                style={{
+                  width: 36, height: 24, borderRadius: 6,
+                  border: `2px solid ${theme === 'dark' ? 'var(--accent)' : 'var(--border)'}`,
+                  cursor: 'pointer',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 11, fontWeight: 500,
+                  color: theme === 'dark' ? 'var(--accent)' : 'var(--text-tertiary)',
+                  background: '#1c1c1a',
+                  fontFamily: 'var(--font)',
+                  transition: 'all 0.15s',
+                }}
+              >
+                ☽
+              </button>
+            </div>
+          </div>
+
+          {/* Accent row */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <div style={{ fontSize: 12, color: 'var(--text-secondary)', minWidth: 52 }}>Accent</div>
+            <div style={{ display: 'flex', gap: '0.45rem' }}>
+              {ACCENT_DEFS.map(def => (
+                <button
+                  key={def.name}
+                  aria-label={`${def.label} accent`}
+                  data-testid={`accent-${def.name}`}
+                  onClick={() => handleAccent(def.name)}
+                  style={{
+                    width: 22, height: 22, borderRadius: '50%',
+                    background: def.value,
+                    border: accent === def.name ? `2px solid ${def.value}` : '2px solid transparent',
+                    cursor: 'pointer',
+                    outline: accent === def.name ? `2px solid ${def.value}` : 'none',
+                    outlineOffset: 2,
+                    padding: 0,
+                    transition: 'all 0.15s',
+                  }}
+                  title={def.label}
+                />
+              ))}
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/kaselog-ui/src/contexts/UserContext.tsx
+++ b/src/kaselog-ui/src/contexts/UserContext.tsx
@@ -1,0 +1,82 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import * as api from '../api/client'
+import type { UserResponse, UpdateUserRequest } from '../api/types'
+import { useTheme } from './ThemeContext'
+import type { Theme, Accent } from './ThemeContext'
+import { ACCENT_DEFS } from './ThemeContext'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface UserContextValue {
+  user: UserResponse | null
+  loading: boolean
+  saveProfile: (data: { firstName: string; lastName: string; email: string }) => Promise<void>
+  saveAppearance: (theme: Theme, accent: Accent) => Promise<void>
+}
+
+const UserContext = createContext<UserContextValue | null>(null)
+
+// ── Provider ──────────────────────────────────────────────────────────────────
+
+export function UserProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<UserResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const { theme, accent, setTheme, setAccent } = useTheme()
+
+  useEffect(() => {
+    api.user.get()
+      .then(u => {
+        setUser(u)
+        // Sync stored appearance from backend if user has saved preferences
+        if (u.firstName !== null || u.lastName !== null || u.email !== null
+            || u.theme !== 'light' || u.accent !== 'teal') {
+          const validAccents = ACCENT_DEFS.map(a => a.name)
+          if ((u.theme === 'light' || u.theme === 'dark') && u.theme !== theme) {
+            setTheme(u.theme as Theme)
+          }
+          if (validAccents.includes(u.accent as Accent) && u.accent !== accent) {
+            setAccent(u.accent as Accent)
+          }
+        }
+      })
+      .catch(() => { /* backend unavailable — continue with defaults */ })
+      .finally(() => setLoading(false))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function saveProfile(data: { firstName: string; lastName: string; email: string }) {
+    const body: UpdateUserRequest = {
+      firstName: data.firstName || null,
+      lastName: data.lastName || null,
+      email: data.email || null,
+      theme,
+      accent,
+    }
+    const updated = await api.user.update(body)
+    setUser(updated)
+  }
+
+  async function saveAppearance(newTheme: Theme, newAccent: Accent) {
+    const body: UpdateUserRequest = {
+      firstName: user?.firstName ?? null,
+      lastName: user?.lastName ?? null,
+      email: user?.email ?? null,
+      theme: newTheme,
+      accent: newAccent,
+    }
+    const updated = await api.user.update(body)
+    setUser(updated)
+  }
+
+  return (
+    <UserContext.Provider value={{ user, loading, saveProfile, saveAppearance }}>
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+export function useUser(): UserContextValue {
+  const ctx = useContext(UserContext)
+  if (!ctx) throw new Error('useUser must be used within UserProvider')
+  return ctx
+}

--- a/src/kaselog-ui/src/test/UserProfile.test.tsx
+++ b/src/kaselog-ui/src/test/UserProfile.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider } from '../contexts/ThemeContext'
+import { UserProvider } from '../contexts/UserContext'
+import UserProfilePanel from '../components/UserProfilePanel'
+import type { UserResponse } from '../api/types'
+
+// ── Mock API ──────────────────────────────────────────────────────────────────
+
+vi.mock('../api/client', () => ({
+  user: {
+    get: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+
+import { user as userApi } from '../api/client'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeUser(overrides: Partial<UserResponse> = {}): UserResponse {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    firstName: null,
+    lastName: null,
+    email: null,
+    theme: 'light',
+    accent: 'teal',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderPanel() {
+  return render(
+    <ThemeProvider>
+      <UserProvider>
+        <UserProfilePanel onClose={() => {}} />
+      </UserProvider>
+    </ThemeProvider>,
+  )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('UserProfilePanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.body.removeAttribute('data-theme')
+    document.body.removeAttribute('data-accent')
+    document.documentElement.style.removeProperty('--accent')
+    vi.mocked(userApi.get).mockResolvedValue(makeUser())
+    vi.mocked(userApi.update).mockImplementation(async body =>
+      makeUser({
+        firstName: body.firstName ?? null,
+        lastName: body.lastName ?? null,
+        email: body.email ?? null,
+        theme: body.theme,
+        accent: body.accent,
+      }),
+    )
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    document.body.removeAttribute('data-theme')
+    document.body.removeAttribute('data-accent')
+    document.documentElement.style.removeProperty('--accent')
+    vi.clearAllMocks()
+  })
+
+  it('renders profile fields', async () => {
+    renderPanel()
+    await waitFor(() => {
+      expect(screen.getByTestId('profile-first-name')).toBeInTheDocument()
+      expect(screen.getByTestId('profile-last-name')).toBeInTheDocument()
+      expect(screen.getByTestId('profile-email')).toBeInTheDocument()
+    })
+  })
+
+  it('pre-populates fields from loaded user', async () => {
+    vi.mocked(userApi.get).mockResolvedValue(makeUser({ firstName: 'Jane', lastName: 'Doe', email: 'jane@example.com' }))
+    renderPanel()
+    await waitFor(() => {
+      expect(screen.getByTestId<HTMLInputElement>('profile-first-name').value).toBe('Jane')
+      expect(screen.getByTestId<HTMLInputElement>('profile-last-name').value).toBe('Doe')
+      expect(screen.getByTestId<HTMLInputElement>('profile-email').value).toBe('jane@example.com')
+    })
+  })
+
+  it('save button calls update with entered profile data', async () => {
+    const ue = userEvent.setup()
+    renderPanel()
+
+    await waitFor(() => screen.getByTestId('profile-first-name'))
+
+    await ue.clear(screen.getByTestId('profile-first-name'))
+    await ue.type(screen.getByTestId('profile-first-name'), 'Alice')
+    await ue.clear(screen.getByTestId('profile-last-name'))
+    await ue.type(screen.getByTestId('profile-last-name'), 'Smith')
+    await ue.clear(screen.getByTestId('profile-email'))
+    await ue.type(screen.getByTestId('profile-email'), 'alice@example.com')
+
+    await ue.click(screen.getByTestId('profile-save-btn'))
+
+    await waitFor(() => {
+      expect(userApi.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          firstName: 'Alice',
+          lastName: 'Smith',
+          email: 'alice@example.com',
+        }),
+      )
+    })
+  })
+
+  it('clicking Dark applies data-theme="dark" to body', async () => {
+    const ue = userEvent.setup()
+    renderPanel()
+
+    await waitFor(() => screen.getByTestId('theme-dark-btn'))
+    await ue.click(screen.getByTestId('theme-dark-btn'))
+
+    expect(document.body.getAttribute('data-theme')).toBe('dark')
+  })
+
+  it('clicking Light applies data-theme="light" to body', async () => {
+    const ue = userEvent.setup()
+    renderPanel()
+
+    await waitFor(() => screen.getByTestId('theme-dark-btn'))
+    await ue.click(screen.getByTestId('theme-dark-btn'))
+    expect(document.body.getAttribute('data-theme')).toBe('dark')
+
+    await ue.click(screen.getByTestId('theme-light-btn'))
+    expect(document.body.getAttribute('data-theme')).toBe('light')
+  })
+
+  it('clicking an accent updates --accent on :root', async () => {
+    const ue = userEvent.setup()
+    renderPanel()
+
+    await waitFor(() => screen.getByTestId('accent-blue'))
+    await ue.click(screen.getByTestId('accent-blue'))
+
+    expect(document.documentElement.style.getPropertyValue('--accent')).toBe('#378ADD')
+  })
+
+  it('theme preference written to localStorage when changed', async () => {
+    const ue = userEvent.setup()
+    renderPanel()
+
+    await waitFor(() => screen.getByTestId('theme-dark-btn'))
+    await ue.click(screen.getByTestId('theme-dark-btn'))
+
+    const stored = JSON.parse(localStorage.getItem('kaselog-prefs') ?? '{}')
+    expect(stored.theme).toBe('dark')
+  })
+
+  it('accent preference written to localStorage when changed', async () => {
+    const ue = userEvent.setup()
+    renderPanel()
+
+    await waitFor(() => screen.getByTestId('accent-purple'))
+    await ue.click(screen.getByTestId('accent-purple'))
+
+    const stored = JSON.parse(localStorage.getItem('kaselog-prefs') ?? '{}')
+    expect(stored.accent).toBe('purple')
+  })
+
+  it('theme and accent changes call api update', async () => {
+    const ue = userEvent.setup()
+    renderPanel()
+
+    await waitFor(() => screen.getByTestId('theme-dark-btn'))
+    await ue.click(screen.getByTestId('theme-dark-btn'))
+
+    await waitFor(() => {
+      expect(userApi.update).toHaveBeenCalledWith(
+        expect.objectContaining({ theme: 'dark' }),
+      )
+    })
+  })
+
+  it('default theme is light when no localStorage value exists', async () => {
+    renderPanel()
+    await waitFor(() => screen.getByTestId('theme-light-btn'))
+    const t = document.body.getAttribute('data-theme')
+    expect(t === null || t === 'light').toBe(true)
+  })
+
+  it('stored preferences restored on simulated reload', () => {
+    localStorage.setItem('kaselog-prefs', JSON.stringify({ theme: 'dark', accent: 'amber' }))
+    renderPanel()
+    expect(document.body.getAttribute('data-theme')).toBe('dark')
+    expect(document.documentElement.style.getPropertyValue('--accent')).toBe('#BA7517')
+  })
+})


### PR DESCRIPTION
## Summary

- **Theme & accent system**: light/dark theme toggle + 5 accent color presets (Teal, Blue, Purple, Coral, Amber) applied via CSS custom properties (`--accent`), persisted to localStorage and backend
- **User profile panel**: replaces the standalone Appearance panel — avatar button in bottom-left nav opens a panel with editable First Name, Last Name, Email fields plus the inline theme/accent controls
- **Backend**: `Users` table (single-row, well-known ID), `GET /api/user` returns current profile (defaults if empty), `PUT /api/user` upserts the record
- **LeftNav**: avatar circle shows user initials computed from saved profile; label shows full name or "Profile" as fallback
- **Persistence**: theme/accent changes update both localStorage (anti-flash) and backend simultaneously; profile saved explicitly via Save button

## Test plan

- [x] All 70 frontend tests pass
- [x] 10 new `UserProfile.test.tsx` tests covering: field rendering, pre-population from API, save button, dark/light theme toggle, accent picker, localStorage write, theme/accent API sync, defaults, localStorage restore
- [ ] `docker compose up --build` — verified clean in CI (dotnet not in bash PATH locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)