### PR TITLE
feat: Collections database schema, FTS5 extension, and cascade guarantees

### DIFF
--- a/src/KaseLog.Api/Data/Sqlite/SqliteSchemaInitializer.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteSchemaInitializer.cs
@@ -76,11 +76,16 @@ public sealed class SqliteSchemaInitializer : ISchemaInitializer
         """,
 
         // ── FTS5 virtual table ───────────────────────────────────────────────
+        // entity_id  — Log.Id or CollectionItem.Id
+        // entity_type — 'log' or 'collection_item'
         """
         CREATE VIRTUAL TABLE IF NOT EXISTS kaselog_search USING fts5(
-          log_id    UNINDEXED,
-          kase_id   UNINDEXED,
+          entity_id        UNINDEXED,
+          entity_type      UNINDEXED,
+          kase_id          UNINDEXED,
           kase_title,
+          collection_id    UNINDEXED,
+          collection_title,
           title,
           content
         )
@@ -101,16 +106,59 @@ public sealed class SqliteSchemaInitializer : ISchemaInitializer
         )
         """,
 
-        // ── FTS5 sync triggers ───────────────────────────────────────────────
+        // ── Collections tables ───────────────────────────────────────────────
+        """
+        CREATE TABLE IF NOT EXISTS Collections (
+          Id        TEXT PRIMARY KEY,
+          Title     TEXT NOT NULL,
+          Color     TEXT NOT NULL DEFAULT 'teal',
+          CreatedAt TEXT NOT NULL,
+          UpdatedAt TEXT NOT NULL
+        )
+        """,
+
+        """
+        CREATE TABLE IF NOT EXISTS CollectionFields (
+          Id           TEXT PRIMARY KEY,
+          CollectionId TEXT NOT NULL REFERENCES Collections(Id) ON DELETE CASCADE,
+          Name         TEXT NOT NULL,
+          Type         TEXT NOT NULL,
+          Required     INTEGER NOT NULL DEFAULT 0,
+          ShowInList   INTEGER NOT NULL DEFAULT 1,
+          Options      TEXT,
+          SortOrder    INTEGER NOT NULL DEFAULT 0
+        )
+        """,
+
+        """
+        CREATE TABLE IF NOT EXISTS CollectionLayout (
+          Id           TEXT PRIMARY KEY,
+          CollectionId TEXT NOT NULL UNIQUE REFERENCES Collections(Id) ON DELETE CASCADE,
+          Layout       TEXT NOT NULL
+        )
+        """,
+
+        """
+        CREATE TABLE IF NOT EXISTS CollectionItems (
+          Id           TEXT PRIMARY KEY,
+          CollectionId TEXT NOT NULL REFERENCES Collections(Id) ON DELETE CASCADE,
+          KaseId       TEXT REFERENCES Kases(Id) ON DELETE SET NULL,
+          FieldValues  TEXT NOT NULL,
+          CreatedAt    TEXT NOT NULL,
+          UpdatedAt    TEXT NOT NULL
+        )
+        """,
+
+        // ── FTS5 sync triggers: Logs ─────────────────────────────────────────
         // One FTS row per Log, always reflecting the most recent LogVersion.
         // INSERT: replace existing FTS entry with the new version's content.
         """
         CREATE TRIGGER IF NOT EXISTS fts_logversion_insert
         AFTER INSERT ON LogVersions
         BEGIN
-          DELETE FROM kaselog_search WHERE log_id = NEW.LogId;
-          INSERT INTO kaselog_search(log_id, kase_id, kase_title, title, content)
-          SELECT NEW.LogId, l.KaseId, k.Title, l.Title, NEW.Content
+          DELETE FROM kaselog_search WHERE entity_id = NEW.LogId AND entity_type = 'log';
+          INSERT INTO kaselog_search(entity_id, entity_type, kase_id, kase_title, collection_id, collection_title, title, content)
+          SELECT NEW.LogId, 'log', l.KaseId, k.Title, NULL, NULL, l.Title, NEW.Content
           FROM Logs l
           JOIN Kases k ON k.Id = l.KaseId
           WHERE l.Id = NEW.LogId;
@@ -123,9 +171,9 @@ public sealed class SqliteSchemaInitializer : ISchemaInitializer
         CREATE TRIGGER IF NOT EXISTS fts_logversion_update
         AFTER UPDATE ON LogVersions
         BEGIN
-          DELETE FROM kaselog_search WHERE log_id = NEW.LogId;
-          INSERT INTO kaselog_search(log_id, kase_id, kase_title, title, content)
-          SELECT NEW.LogId, l.KaseId, k.Title, l.Title, NEW.Content
+          DELETE FROM kaselog_search WHERE entity_id = NEW.LogId AND entity_type = 'log';
+          INSERT INTO kaselog_search(entity_id, entity_type, kase_id, kase_title, collection_id, collection_title, title, content)
+          SELECT NEW.LogId, 'log', l.KaseId, k.Title, NULL, NULL, l.Title, NEW.Content
           FROM Logs l
           JOIN Kases k ON k.Id = l.KaseId
           WHERE l.Id = NEW.LogId;
@@ -138,9 +186,9 @@ public sealed class SqliteSchemaInitializer : ISchemaInitializer
         CREATE TRIGGER IF NOT EXISTS fts_logversion_delete
         AFTER DELETE ON LogVersions
         BEGIN
-          DELETE FROM kaselog_search WHERE log_id = OLD.LogId;
-          INSERT INTO kaselog_search(log_id, kase_id, kase_title, title, content)
-          SELECT lv.LogId, l.KaseId, k.Title, l.Title, lv.Content
+          DELETE FROM kaselog_search WHERE entity_id = OLD.LogId AND entity_type = 'log';
+          INSERT INTO kaselog_search(entity_id, entity_type, kase_id, kase_title, collection_id, collection_title, title, content)
+          SELECT lv.LogId, 'log', l.KaseId, k.Title, NULL, NULL, l.Title, lv.Content
           FROM LogVersions lv
           JOIN Logs l ON l.Id = lv.LogId
           JOIN Kases k ON k.Id = l.KaseId
@@ -157,7 +205,73 @@ public sealed class SqliteSchemaInitializer : ISchemaInitializer
         CREATE TRIGGER IF NOT EXISTS fts_log_delete
         AFTER DELETE ON Logs
         BEGIN
-          DELETE FROM kaselog_search WHERE log_id = OLD.Id;
+          DELETE FROM kaselog_search WHERE entity_id = OLD.Id AND entity_type = 'log';
+        END
+        """,
+
+        // ── FTS5 sync triggers: CollectionItems ──────────────────────────────
+        // title   = value of the first text/select field by SortOrder
+        // content = space-separated values of all text/multiline/select fields
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_collectionitem_insert
+        AFTER INSERT ON CollectionItems
+        BEGIN
+          INSERT INTO kaselog_search(entity_id, entity_type, kase_id, kase_title, collection_id, collection_title, title, content)
+          SELECT
+            NEW.Id,
+            'collection_item',
+            NEW.KaseId,
+            (SELECT Title FROM Kases WHERE Id = NEW.KaseId),
+            NEW.CollectionId,
+            c.Title,
+            (SELECT json_extract(NEW.FieldValues, '$.' || cf.Id)
+             FROM CollectionFields cf
+             WHERE cf.CollectionId = NEW.CollectionId
+               AND cf.Type IN ('text', 'select')
+             ORDER BY cf.SortOrder
+             LIMIT 1),
+            (SELECT COALESCE(group_concat(COALESCE(json_extract(NEW.FieldValues, '$.' || cf.Id), ''), ' '), '')
+             FROM CollectionFields cf
+             WHERE cf.CollectionId = NEW.CollectionId
+               AND cf.Type IN ('text', 'multiline', 'select'))
+          FROM Collections c
+          WHERE c.Id = NEW.CollectionId;
+        END
+        """,
+
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_collectionitem_update
+        AFTER UPDATE ON CollectionItems
+        BEGIN
+          DELETE FROM kaselog_search WHERE entity_id = OLD.Id AND entity_type = 'collection_item';
+          INSERT INTO kaselog_search(entity_id, entity_type, kase_id, kase_title, collection_id, collection_title, title, content)
+          SELECT
+            NEW.Id,
+            'collection_item',
+            NEW.KaseId,
+            (SELECT Title FROM Kases WHERE Id = NEW.KaseId),
+            NEW.CollectionId,
+            c.Title,
+            (SELECT json_extract(NEW.FieldValues, '$.' || cf.Id)
+             FROM CollectionFields cf
+             WHERE cf.CollectionId = NEW.CollectionId
+               AND cf.Type IN ('text', 'select')
+             ORDER BY cf.SortOrder
+             LIMIT 1),
+            (SELECT COALESCE(group_concat(COALESCE(json_extract(NEW.FieldValues, '$.' || cf.Id), ''), ' '), '')
+             FROM CollectionFields cf
+             WHERE cf.CollectionId = NEW.CollectionId
+               AND cf.Type IN ('text', 'multiline', 'select'))
+          FROM Collections c
+          WHERE c.Id = NEW.CollectionId;
+        END
+        """,
+
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_collectionitem_delete
+        AFTER DELETE ON CollectionItems
+        BEGIN
+          DELETE FROM kaselog_search WHERE entity_id = OLD.Id AND entity_type = 'collection_item';
         END
         """,
     ];

--- a/src/KaseLog.Api/Data/Sqlite/SqliteSearchRepository.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteSearchRepository.cs
@@ -44,6 +44,7 @@ public sealed partial class SqliteSearchRepository : ISearchRepository
             LogId = r.LogId,
             KaseId = r.KaseId,
             KaseTitle = r.KaseTitle,
+            EntityType = r.EntityType,
             Title = r.Title,
             Highlight = BuildHighlight(r.Content, hasQ ? q : null),
             Tags = tagMap.TryGetValue(r.LogId, out var t) ? t : [],
@@ -64,15 +65,17 @@ public sealed partial class SqliteSearchRepository : ISearchRepository
         var ftsQuery = BuildFtsQuery(q);
         var sql = new StringBuilder("""
             SELECT
-                kaselog_search.log_id     AS LogId,
-                kaselog_search.kase_id    AS KaseId,
-                kaselog_search.kase_title AS KaseTitle,
-                kaselog_search.title      AS Title,
-                kaselog_search.content    AS Content,
+                kaselog_search.entity_id   AS LogId,
+                kaselog_search.kase_id     AS KaseId,
+                kaselog_search.kase_title  AS KaseTitle,
+                kaselog_search.entity_type AS EntityType,
+                kaselog_search.title       AS Title,
+                kaselog_search.content     AS Content,
                 l.UpdatedAt
             FROM kaselog_search
-            JOIN Logs l ON l.Id = kaselog_search.log_id
+            JOIN Logs l ON l.Id = kaselog_search.entity_id
             WHERE kaselog_search MATCH @ftsQuery
+              AND kaselog_search.entity_type = 'log'
             """);
 
         var p = new DynamicParameters();
@@ -84,7 +87,7 @@ public sealed partial class SqliteSearchRepository : ISearchRepository
             p.Add("kaseId", kaseId);
         }
 
-        AppendDateAndTagFilters(sql, p, tags, from, to, "kaselog_search.log_id");
+        AppendDateAndTagFilters(sql, p, tags, from, to, "kaselog_search.entity_id");
 
         sql.AppendLine(" ORDER BY rank LIMIT 100");
 
@@ -277,6 +280,7 @@ public sealed partial class SqliteSearchRepository : ISearchRepository
         public string LogId { get; init; } = string.Empty;
         public string KaseId { get; init; } = string.Empty;
         public string KaseTitle { get; init; } = string.Empty;
+        public string EntityType { get; init; } = "log";
         public string Title { get; init; } = string.Empty;
         public string Content { get; init; } = string.Empty;
         public string UpdatedAt { get; init; } = string.Empty;

--- a/src/KaseLog.Api/Models/SearchResultDto.cs
+++ b/src/KaseLog.Api/Models/SearchResultDto.cs
@@ -5,6 +5,7 @@ public sealed class SearchResultDto
     public required string LogId { get; init; }
     public required string KaseId { get; init; }
     public required string KaseTitle { get; init; }
+    public string EntityType { get; init; } = "log";
     public required string Title { get; init; }
     public string Highlight { get; init; } = string.Empty;
     public IReadOnlyList<string> Tags { get; init; } = [];

--- a/tests/KaseLog.Api.Tests/Controllers/LogsControllerTests.cs
+++ b/tests/KaseLog.Api.Tests/Controllers/LogsControllerTests.cs
@@ -292,14 +292,14 @@ public sealed class LogsControllerTests : IAsyncLifetime
         // Verify FTS entry exists before delete
         await using var conn = await OpenTestConnectionAsync();
         var beforeCount = await conn.ExecuteScalarAsync<int>(
-            "SELECT COUNT(*) FROM kaselog_search WHERE log_id = @LogId",
+            "SELECT COUNT(*) FROM kaselog_search WHERE entity_id = @LogId AND entity_type = 'log'",
             new { LogId = logId });
         Assert.Equal(1, beforeCount);
 
         await _client.DeleteAsync($"/api/logs/{logId}");
 
         var afterCount = await conn.ExecuteScalarAsync<int>(
-            "SELECT COUNT(*) FROM kaselog_search WHERE log_id = @LogId",
+            "SELECT COUNT(*) FROM kaselog_search WHERE entity_id = @LogId AND entity_type = 'log'",
             new { LogId = logId });
         Assert.Equal(0, afterCount);
     }

--- a/tests/KaseLog.Api.Tests/Data/SchemaTests.cs
+++ b/tests/KaseLog.Api.Tests/Data/SchemaTests.cs
@@ -82,6 +82,38 @@ public sealed class SchemaTests : IAsyncDisposable
             new { LogId = logId, TagId = tagId });
     }
 
+    private async Task InsertCollectionAsync(IDbConnection conn, string id, string title = "Test Collection", string color = "teal")
+    {
+        var now = Now();
+        await conn.ExecuteAsync(
+            "INSERT INTO Collections(Id, Title, Color, CreatedAt, UpdatedAt) VALUES (@Id, @Title, @Color, @Now, @Now)",
+            new { Id = id, Title = title, Color = color, Now = now });
+    }
+
+    private async Task InsertCollectionFieldAsync(IDbConnection conn, string id, string collectionId,
+        string name = "Field", string type = "text", int sortOrder = 0)
+    {
+        await conn.ExecuteAsync(
+            "INSERT INTO CollectionFields(Id, CollectionId, Name, Type, SortOrder) VALUES (@Id, @CollectionId, @Name, @Type, @SortOrder)",
+            new { Id = id, CollectionId = collectionId, Name = name, Type = type, SortOrder = sortOrder });
+    }
+
+    private async Task InsertCollectionLayoutAsync(IDbConnection conn, string id, string collectionId, string layout = "[]")
+    {
+        await conn.ExecuteAsync(
+            "INSERT INTO CollectionLayout(Id, CollectionId, Layout) VALUES (@Id, @CollectionId, @Layout)",
+            new { Id = id, CollectionId = collectionId, Layout = layout });
+    }
+
+    private async Task InsertCollectionItemAsync(IDbConnection conn, string id, string collectionId,
+        string fieldValues = "{}", string? kaseId = null)
+    {
+        var now = Now();
+        await conn.ExecuteAsync(
+            "INSERT INTO CollectionItems(Id, CollectionId, KaseId, FieldValues, CreatedAt, UpdatedAt) VALUES (@Id, @CollectionId, @KaseId, @FieldValues, @Now, @Now)",
+            new { Id = id, CollectionId = collectionId, KaseId = kaseId, FieldValues = fieldValues, Now = now });
+    }
+
     // ── Tests ─────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -186,7 +218,7 @@ public sealed class SchemaTests : IAsyncDisposable
         await InsertLogVersionAsync(conn, versionId, logId, "searchable content here");
 
         var count = await conn.ExecuteScalarAsync<long>(
-            "SELECT count(*) FROM kaselog_search WHERE log_id = @LogId",
+            "SELECT count(*) FROM kaselog_search WHERE entity_id = @LogId AND entity_type = 'log'",
             new { LogId = logId });
 
         Assert.Equal(1L, count);
@@ -209,13 +241,15 @@ public sealed class SchemaTests : IAsyncDisposable
 
         // Confirm FTS entry exists
         Assert.Equal(1L, await conn.ExecuteScalarAsync<long>(
-            "SELECT count(*) FROM kaselog_search WHERE log_id = @LogId", new { LogId = logId }));
+            "SELECT count(*) FROM kaselog_search WHERE entity_id = @LogId AND entity_type = 'log'",
+            new { LogId = logId }));
 
         await conn.ExecuteAsync("DELETE FROM LogVersions WHERE Id = @Id", new { Id = versionId });
 
         // No remaining versions — FTS entry should be gone
         Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
-            "SELECT count(*) FROM kaselog_search WHERE log_id = @LogId", new { LogId = logId }));
+            "SELECT count(*) FROM kaselog_search WHERE entity_id = @LogId AND entity_type = 'log'",
+            new { LogId = logId }));
     }
 
     [Fact]
@@ -242,9 +276,262 @@ public sealed class SchemaTests : IAsyncDisposable
         await conn.ExecuteAsync("DELETE FROM LogVersions WHERE Id = @Id", new { Id = v1Id });
 
         var ftsContent = await conn.ExecuteScalarAsync<string>(
-            "SELECT content FROM kaselog_search WHERE log_id = @LogId",
+            "SELECT content FROM kaselog_search WHERE entity_id = @LogId AND entity_type = 'log'",
             new { LogId = logId });
 
         Assert.Equal("version two content", ftsContent);
+    }
+
+    // ── Collections schema tests ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Collections_AllTablesInitializeCorrectly()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        var tables = (await conn.QueryAsync<string>(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"))
+            .ToHashSet();
+
+        Assert.Contains("Collections",       tables);
+        Assert.Contains("CollectionFields",  tables);
+        Assert.Contains("CollectionLayout",  tables);
+        Assert.Contains("CollectionItems",   tables);
+    }
+
+    [Fact]
+    public async Task Collections_Cascade_DeletingCollection_RemovesFieldsLayoutAndItems()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        var collectionId = NewId();
+        var fieldId      = NewId();
+        var layoutId     = NewId();
+        var itemId       = NewId();
+
+        await InsertCollectionAsync(conn, collectionId);
+        await InsertCollectionFieldAsync(conn, fieldId, collectionId);
+        await InsertCollectionLayoutAsync(conn, layoutId, collectionId);
+        await InsertCollectionItemAsync(conn, itemId, collectionId);
+
+        await conn.ExecuteAsync("DELETE FROM Collections WHERE Id = @Id", new { Id = collectionId });
+
+        Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM CollectionFields WHERE CollectionId = @Id", new { Id = collectionId }));
+        Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM CollectionLayout WHERE CollectionId = @Id", new { Id = collectionId }));
+        Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM CollectionItems WHERE CollectionId = @Id", new { Id = collectionId }));
+    }
+
+    [Fact]
+    public async Task Collections_DeletingKase_SetsKaseIdNullOnLinkedItems()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        var kaseId       = NewId();
+        var collectionId = NewId();
+        var itemId       = NewId();
+
+        await InsertKaseAsync(conn, kaseId);
+        await InsertCollectionAsync(conn, collectionId);
+        await InsertCollectionItemAsync(conn, itemId, collectionId, kaseId: kaseId);
+
+        // Sanity: KaseId is set before delete
+        var kaseIdBefore = await conn.ExecuteScalarAsync<string?>(
+            "SELECT KaseId FROM CollectionItems WHERE Id = @Id", new { Id = itemId });
+        Assert.Equal(kaseId, kaseIdBefore);
+
+        await conn.ExecuteAsync("DELETE FROM Kases WHERE Id = @Id", new { Id = kaseId });
+
+        // Item still exists, KaseId is NULL
+        var kaseIdAfter = await conn.ExecuteScalarAsync<string?>(
+            "SELECT KaseId FROM CollectionItems WHERE Id = @Id", new { Id = itemId });
+        Assert.Null(kaseIdAfter);
+
+        Assert.Equal(1L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM CollectionItems WHERE Id = @Id", new { Id = itemId }));
+    }
+
+    [Fact]
+    public async Task Collections_FieldReorder_UpdatesSortOrderAtomically()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        var collectionId = NewId();
+        var fieldA       = NewId();
+        var fieldB       = NewId();
+        var fieldC       = NewId();
+
+        await InsertCollectionAsync(conn, collectionId);
+        await InsertCollectionFieldAsync(conn, fieldA, collectionId, "Field A", sortOrder: 0);
+        await InsertCollectionFieldAsync(conn, fieldB, collectionId, "Field B", sortOrder: 1);
+        await InsertCollectionFieldAsync(conn, fieldC, collectionId, "Field C", sortOrder: 2);
+
+        // Reverse the order atomically
+        using var tx = conn.BeginTransaction();
+        await conn.ExecuteAsync("UPDATE CollectionFields SET SortOrder = @S WHERE Id = @Id",
+            new { Id = fieldA, S = 2 }, tx);
+        await conn.ExecuteAsync("UPDATE CollectionFields SET SortOrder = @S WHERE Id = @Id",
+            new { Id = fieldB, S = 1 }, tx);
+        await conn.ExecuteAsync("UPDATE CollectionFields SET SortOrder = @S WHERE Id = @Id",
+            new { Id = fieldC, S = 0 }, tx);
+        tx.Commit();
+
+        var orders = (await conn.QueryAsync<(string Id, int SortOrder)>(
+            "SELECT Id, SortOrder FROM CollectionFields WHERE CollectionId = @Id ORDER BY SortOrder",
+            new { Id = collectionId })).ToList();
+
+        Assert.Equal(fieldC, orders[0].Id);
+        Assert.Equal(fieldB, orders[1].Id);
+        Assert.Equal(fieldA, orders[2].Id);
+    }
+
+    [Fact]
+    public async Task Collections_Layout_UniquePerCollection_UpsertBehavior()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        var collectionId = NewId();
+        var layoutId1    = NewId();
+        var layoutId2    = NewId();
+
+        await InsertCollectionAsync(conn, collectionId);
+        await InsertCollectionLayoutAsync(conn, layoutId1, collectionId, "[{\"cells\":[]}]");
+
+        // Upsert: replace layout for same collection
+        await conn.ExecuteAsync("""
+            INSERT INTO CollectionLayout(Id, CollectionId, Layout)
+            VALUES (@Id, @CollectionId, @Layout)
+            ON CONFLICT(CollectionId) DO UPDATE SET Layout = excluded.Layout
+            """,
+            new { Id = layoutId2, CollectionId = collectionId, Layout = "[{\"cells\":[]},{\"cells\":[]}]" });
+
+        var count = await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM CollectionLayout WHERE CollectionId = @Id", new { Id = collectionId });
+        var layout = await conn.ExecuteScalarAsync<string>(
+            "SELECT Layout FROM CollectionLayout WHERE CollectionId = @Id", new { Id = collectionId });
+
+        Assert.Equal(1L, count);
+        Assert.Equal("[{\"cells\":[]},{\"cells\":[]}]", layout);
+    }
+
+    [Fact]
+    public async Task Collections_Fts_UpdatesOnCollectionItemInsert()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        var collectionId = NewId();
+        var fieldId      = NewId();
+        var itemId       = NewId();
+
+        await InsertCollectionAsync(conn, collectionId, "My Books");
+        await InsertCollectionFieldAsync(conn, fieldId, collectionId, "Title", "text", sortOrder: 0);
+        var fieldValues = $"{{\"{fieldId}\": \"Dune\"}}";
+        await InsertCollectionItemAsync(conn, itemId, collectionId, fieldValues);
+
+        var entityType = await conn.ExecuteScalarAsync<string>(
+            "SELECT entity_type FROM kaselog_search WHERE entity_id = @Id",
+            new { Id = itemId });
+
+        Assert.Equal("collection_item", entityType);
+    }
+
+    [Fact]
+    public async Task Collections_Fts_UpdatesOnCollectionItemUpdate()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        var collectionId = NewId();
+        var fieldId      = NewId();
+        var itemId       = NewId();
+
+        await InsertCollectionAsync(conn, collectionId);
+        await InsertCollectionFieldAsync(conn, fieldId, collectionId, "Title", "text", sortOrder: 0);
+        var fieldValues = $"{{\"{fieldId}\": \"Original\"}}";
+        await InsertCollectionItemAsync(conn, itemId, collectionId, fieldValues);
+
+        // Update the item with new field values
+        var updatedValues = $"{{\"{fieldId}\": \"Updated\"}}";
+        await conn.ExecuteAsync(
+            "UPDATE CollectionItems SET FieldValues = @FV, UpdatedAt = @Now WHERE Id = @Id",
+            new { FV = updatedValues, Now = Now(), Id = itemId });
+
+        var ftsTitle = await conn.ExecuteScalarAsync<string>(
+            "SELECT title FROM kaselog_search WHERE entity_id = @Id AND entity_type = 'collection_item'",
+            new { Id = itemId });
+
+        Assert.Equal("Updated", ftsTitle);
+    }
+
+    [Fact]
+    public async Task Collections_Fts_EntryRemovedOnCollectionItemDelete()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        var collectionId = NewId();
+        var itemId       = NewId();
+
+        await InsertCollectionAsync(conn, collectionId);
+        await InsertCollectionItemAsync(conn, itemId, collectionId);
+
+        Assert.Equal(1L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM kaselog_search WHERE entity_id = @Id AND entity_type = 'collection_item'",
+            new { Id = itemId }));
+
+        await conn.ExecuteAsync("DELETE FROM CollectionItems WHERE Id = @Id", new { Id = itemId });
+
+        Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM kaselog_search WHERE entity_id = @Id AND entity_type = 'collection_item'",
+            new { Id = itemId }));
+    }
+
+    [Fact]
+    public async Task Collections_Fts_SearchReturnsBothLogAndCollectionItemEntityTypes()
+    {
+        await InitializeAsync();
+
+        using var conn = await _factory.OpenAsync();
+
+        // Insert a log with FTS entry
+        var kaseId       = NewId();
+        var logId        = NewId();
+        var versionId    = NewId();
+        var collectionId = NewId();
+        var fieldId      = NewId();
+        var itemId       = NewId();
+
+        await InsertKaseAsync(conn, kaseId);
+        await InsertLogAsync(conn, logId, kaseId);
+        await InsertLogVersionAsync(conn, versionId, logId, "searchable log content");
+
+        // Insert a collection item with FTS entry
+        await InsertCollectionAsync(conn, collectionId);
+        await InsertCollectionFieldAsync(conn, fieldId, collectionId, "Name", "text", sortOrder: 0);
+        var fieldValues = $"{{\"{fieldId}\": \"searchable item\"}}";
+        await InsertCollectionItemAsync(conn, itemId, collectionId, fieldValues);
+
+        var entityTypes = (await conn.QueryAsync<string>(
+            "SELECT entity_type FROM kaselog_search ORDER BY entity_type"))
+            .ToList();
+
+        Assert.Contains("log",             entityTypes);
+        Assert.Contains("collection_item", entityTypes);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Collections`, `CollectionFields`, `CollectionLayout`, and `CollectionItems` tables with correct FK relationships and cascade rules
- Updates FTS5 virtual table schema: `log_id` → `entity_id` + `entity_type`, adds `collection_id` and `collection_title` columns
- Updates all log FTS5 triggers to use new column names (`entity_type = 'log'`)
- Adds three new FTS5 triggers for `CollectionItems` (insert, update, delete) with `entity_type = 'collection_item'`
- Title populated from first `text`/`select` field by `SortOrder`; content is space-joined values of all `text`, `multiline`, and `select` fields
- Adds `EntityType` to `SearchResultDto`; existing log search filters by `entity_type = 'log'` to preserve API contract
- Updates existing FTS test queries in `SchemaTests` and `LogsControllerTests` from `log_id` to `entity_id`

## Test plan

- [ ] All 46 backend tests pass (`dotnet test tests/KaseLog.Api.Tests`)
- [ ] `Collections_AllTablesInitializeCorrectly` — all four tables present after init
- [ ] `Collections_Cascade_DeletingCollection_RemovesFieldsLayoutAndItems` — cascade verified
- [ ] `Collections_DeletingKase_SetsKaseIdNullOnLinkedItems` — SET NULL verified (item not deleted)
- [ ] `Collections_FieldReorder_UpdatesSortOrderAtomically` — reorder transaction verified
- [ ] `Collections_Layout_UniquePerCollection_UpsertBehavior` — ON CONFLICT upsert verified
- [ ] `Collections_Fts_UpdatesOnCollectionItemInsert` — entity_type='collection_item' present after insert
- [ ] `Collections_Fts_UpdatesOnCollectionItemUpdate` — FTS title updated after item update
- [ ] `Collections_Fts_EntryRemovedOnCollectionItemDelete` — FTS entry removed on delete
- [ ] `Collections_Fts_SearchReturnsBothLogAndCollectionItemEntityTypes` — both entity types in FTS table

🤖 Generated with [Claude Code](https://claude.com/claude-code)