### PR TITLE
feat: Collections API — CRUD, fields, layout, items, timeline

### DIFF
--- a/src/KaseLog.Api/Controllers/CollectionItemsController.cs
+++ b/src/KaseLog.Api/Controllers/CollectionItemsController.cs
@@ -1,0 +1,65 @@
+using KaseLog.Api.Data;
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KaseLog.Api.Controllers;
+
+/// <summary>Individual Collection item endpoints: GET, PUT, DELETE /api/items/{id}.</summary>
+[ApiController]
+[Route("api/items")]
+[Produces("application/json")]
+public sealed class CollectionItemsController : ControllerBase
+{
+    private readonly ICollectionRepository _collections;
+
+    public CollectionItemsController(ICollectionRepository collections) => _collections = collections;
+
+    /// <summary>Returns a Collection item by ID.</summary>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionItemResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetItem(Guid id)
+    {
+        var item = await _collections.GetItemAsync(id);
+        if (item is null)
+            return NotFound(ApiResponse<CollectionItemResponse>.NotFound($"Item '{id}' was not found."));
+        return Ok(ApiResponse<CollectionItemResponse>.Success(item));
+    }
+
+    /// <summary>Updates a Collection item's field values and optional Kase link.</summary>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionItemResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateItem(Guid id, [FromBody] UpdateCollectionItemRequest request)
+    {
+        try
+        {
+            var item = await _collections.UpdateItemAsync(id, request);
+            if (item is null)
+                return NotFound(ApiResponse<CollectionItemResponse>.NotFound($"Item '{id}' was not found."));
+            return Ok(ApiResponse<CollectionItemResponse>.Success(item));
+        }
+        catch (CollectionItemValidationException ex)
+        {
+            return BadRequest(ApiResponse<CollectionItemResponse>.Failure(
+                "https://tools.ietf.org/html/rfc7807",
+                "Validation failed", 400,
+                "One or more required fields are missing or empty.",
+                ex.FieldErrors));
+        }
+    }
+
+    /// <summary>Deletes a Collection item.</summary>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteItem(Guid id)
+    {
+        var deleted = await _collections.DeleteItemAsync(id);
+        if (!deleted)
+            return NotFound(ApiResponse<CollectionItemResponse>.NotFound($"Item '{id}' was not found."));
+        return NoContent();
+    }
+}

--- a/src/KaseLog.Api/Controllers/CollectionsController.cs
+++ b/src/KaseLog.Api/Controllers/CollectionsController.cs
@@ -1,0 +1,248 @@
+using KaseLog.Api.Data;
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KaseLog.Api.Controllers;
+
+/// <summary>Collections CRUD, fields, layout, and items list.</summary>
+[ApiController]
+[Produces("application/json")]
+public sealed class CollectionsController : ControllerBase
+{
+    private static readonly HashSet<string> ValidColors =
+        ["teal", "blue", "purple", "coral", "amber"];
+
+    private static readonly HashSet<string> ValidFieldTypes =
+        ["text", "multiline", "number", "date", "select", "rating", "url", "boolean", "image"];
+
+    private readonly ICollectionRepository _collections;
+
+    public CollectionsController(ICollectionRepository collections) => _collections = collections;
+
+    // ── Collections ───────────────────────────────────────────────────────────
+
+    /// <summary>Returns all Collections ordered by most-recently updated.</summary>
+    [HttpGet("api/collections")]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<CollectionResponse>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAll()
+    {
+        var items = await _collections.GetAllAsync();
+        return Ok(ApiResponse<IEnumerable<CollectionResponse>>.Success(items));
+    }
+
+    /// <summary>Creates a new Collection.</summary>
+    [HttpPost("api/collections")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionResponse>), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create([FromBody] CreateCollectionRequest request)
+    {
+        if (!ValidColors.Contains(request.Color.Trim().ToLowerInvariant()))
+            return BadRequest(ApiResponse<CollectionResponse>.Failure(
+                "https://tools.ietf.org/html/rfc7807",
+                "Validation failed", 400,
+                $"Color must be one of: {string.Join(", ", ValidColors)}."));
+
+        var collection = await _collections.CreateAsync(request);
+        return CreatedAtAction(nameof(GetById), new { id = collection.Id },
+            ApiResponse<CollectionResponse>.Success(collection));
+    }
+
+    /// <summary>Returns a Collection by ID.</summary>
+    [HttpGet("api/collections/{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var collection = await _collections.GetByIdAsync(id);
+        if (collection is null)
+            return NotFound(ApiResponse<CollectionResponse>.NotFound($"Collection '{id}' was not found."));
+        return Ok(ApiResponse<CollectionResponse>.Success(collection));
+    }
+
+    /// <summary>Updates a Collection's title and color.</summary>
+    [HttpPut("api/collections/{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateCollectionRequest request)
+    {
+        if (!ValidColors.Contains(request.Color.Trim().ToLowerInvariant()))
+            return BadRequest(ApiResponse<CollectionResponse>.Failure(
+                "https://tools.ietf.org/html/rfc7807",
+                "Validation failed", 400,
+                $"Color must be one of: {string.Join(", ", ValidColors)}."));
+
+        var collection = await _collections.UpdateAsync(id, request);
+        if (collection is null)
+            return NotFound(ApiResponse<CollectionResponse>.NotFound($"Collection '{id}' was not found."));
+        return Ok(ApiResponse<CollectionResponse>.Success(collection));
+    }
+
+    /// <summary>Deletes a Collection and all its fields, layout, and items.</summary>
+    [HttpDelete("api/collections/{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var deleted = await _collections.DeleteAsync(id);
+        if (!deleted)
+            return NotFound(ApiResponse<CollectionResponse>.NotFound($"Collection '{id}' was not found."));
+        return NoContent();
+    }
+
+    // ── Fields ────────────────────────────────────────────────────────────────
+
+    /// <summary>Returns all fields for a Collection ordered by SortOrder.</summary>
+    [HttpGet("api/collections/{id:guid}/fields")]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<CollectionFieldResponse>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetFields(Guid id)
+    {
+        var fields = await _collections.GetFieldsAsync(id);
+        return Ok(ApiResponse<IEnumerable<CollectionFieldResponse>>.Success(fields));
+    }
+
+    /// <summary>Adds a field to a Collection schema.</summary>
+    [HttpPost("api/collections/{id:guid}/fields")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionFieldResponse>), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> AddField(Guid id, [FromBody] CreateCollectionFieldRequest request)
+    {
+        if (!ValidFieldTypes.Contains(request.Type.Trim().ToLowerInvariant()))
+            return BadRequest(ApiResponse<CollectionFieldResponse>.Failure(
+                "https://tools.ietf.org/html/rfc7807",
+                "Validation failed", 400,
+                $"Type must be one of: {string.Join(", ", ValidFieldTypes)}."));
+
+        var field = await _collections.AddFieldAsync(id, request);
+        return CreatedAtAction(nameof(GetFields), new { id },
+            ApiResponse<CollectionFieldResponse>.Success(field));
+    }
+
+    /// <summary>Updates a field definition.</summary>
+    [HttpPut("api/collections/{id:guid}/fields/{fieldId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionFieldResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateField(Guid id, Guid fieldId,
+        [FromBody] UpdateCollectionFieldRequest request)
+    {
+        if (!ValidFieldTypes.Contains(request.Type.Trim().ToLowerInvariant()))
+            return BadRequest(ApiResponse<CollectionFieldResponse>.Failure(
+                "https://tools.ietf.org/html/rfc7807",
+                "Validation failed", 400,
+                $"Type must be one of: {string.Join(", ", ValidFieldTypes)}."));
+
+        var field = await _collections.UpdateFieldAsync(id, fieldId, request);
+        if (field is null)
+            return NotFound(ApiResponse<CollectionFieldResponse>.NotFound(
+                $"Field '{fieldId}' not found in collection '{id}'."));
+        return Ok(ApiResponse<CollectionFieldResponse>.Success(field));
+    }
+
+    /// <summary>Deletes a field from a Collection schema.</summary>
+    [HttpDelete("api/collections/{id:guid}/fields/{fieldId:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteField(Guid id, Guid fieldId)
+    {
+        var deleted = await _collections.DeleteFieldAsync(id, fieldId);
+        if (!deleted)
+            return NotFound(ApiResponse<CollectionFieldResponse>.NotFound(
+                $"Field '{fieldId}' not found in collection '{id}'."));
+        return NoContent();
+    }
+
+    /// <summary>Reorders all fields for a Collection in a single transaction.</summary>
+    [HttpPut("api/collections/{id:guid}/fields/reorder")]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<CollectionFieldResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ReorderFields(Guid id, [FromBody] ReorderFieldsRequest request)
+    {
+        var ok = await _collections.ReorderFieldsAsync(id, request.FieldIds);
+        if (!ok)
+            return NotFound(ApiResponse<CollectionFieldResponse>.NotFound($"Collection '{id}' was not found."));
+
+        var fields = await _collections.GetFieldsAsync(id);
+        return Ok(ApiResponse<IEnumerable<CollectionFieldResponse>>.Success(fields));
+    }
+
+    // ── Layout ────────────────────────────────────────────────────────────────
+
+    /// <summary>Returns the layout JSON for a Collection.</summary>
+    [HttpGet("api/collections/{id:guid}/layout")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionLayoutResponse>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetLayout(Guid id)
+    {
+        var layout = await _collections.GetLayoutAsync(id) ?? new CollectionLayoutResponse
+        {
+            CollectionId = id,
+            Layout       = "[]",
+        };
+        return Ok(ApiResponse<CollectionLayoutResponse>.Success(layout));
+    }
+
+    /// <summary>Replaces the layout for a Collection atomically.</summary>
+    [HttpPut("api/collections/{id:guid}/layout")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionLayoutResponse>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpsertLayout(Guid id, [FromBody] UpdateCollectionLayoutRequest request)
+    {
+        var layout = await _collections.UpsertLayoutAsync(id, request.Layout);
+        return Ok(ApiResponse<CollectionLayoutResponse>.Success(layout));
+    }
+
+    // ── Items ─────────────────────────────────────────────────────────────────
+
+    /// <summary>Returns items in a Collection with optional filtering, sorting, and pagination.</summary>
+    [HttpGet("api/collections/{id:guid}/items")]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<CollectionItemResponse>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetItems(
+        Guid id,
+        [FromQuery] string? q,
+        [FromQuery] Guid? kaseId,
+        [FromQuery(Name = "field")] Dictionary<string, string>? field,
+        [FromQuery] string? sort,
+        [FromQuery] string? dir,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50)
+    {
+        var items = await _collections.GetItemsAsync(
+            id,
+            q,
+            kaseId,
+            (IReadOnlyDictionary<string, string>?)field ?? new Dictionary<string, string>(),
+            sort,
+            !string.Equals(dir, "desc", StringComparison.OrdinalIgnoreCase),
+            Math.Max(1, page),
+            Math.Clamp(pageSize, 1, 200));
+
+        return Ok(ApiResponse<IEnumerable<CollectionItemResponse>>.Success(items));
+    }
+
+    /// <summary>Creates a new Collection item, validating required fields.</summary>
+    [HttpPost("api/collections/{id:guid}/items")]
+    [ProducesResponseType(typeof(ApiResponse<CollectionItemResponse>), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateItem(Guid id, [FromBody] CreateCollectionItemRequest request)
+    {
+        // Ensure collection exists
+        var collection = await _collections.GetByIdAsync(id);
+        if (collection is null)
+            return NotFound(ApiResponse<CollectionItemResponse>.NotFound($"Collection '{id}' was not found."));
+
+        try
+        {
+            var item = await _collections.CreateItemAsync(id, request);
+            return CreatedAtAction(nameof(CollectionItemsController.GetItem),
+                "CollectionItems", new { id = item.Id },
+                ApiResponse<CollectionItemResponse>.Success(item));
+        }
+        catch (CollectionItemValidationException ex)
+        {
+            return BadRequest(ApiResponse<CollectionItemResponse>.Failure(
+                "https://tools.ietf.org/html/rfc7807",
+                "Validation failed", 400,
+                "One or more required fields are missing or empty.",
+                ex.FieldErrors));
+        }
+    }
+}

--- a/src/KaseLog.Api/Controllers/KasesController.cs
+++ b/src/KaseLog.Api/Controllers/KasesController.cs
@@ -82,4 +82,22 @@ public sealed class KasesController : ControllerBase
             return NotFound(ApiResponse<KaseResponse>.NotFound($"Kase with ID '{id}' was not found."));
         return NoContent();
     }
+
+    /// <summary>Returns Logs and linked Collection items for a Kase in reverse-chronological order.</summary>
+    [HttpGet("{id:guid}/timeline")]
+    [ProducesResponseType(typeof(ApiResponse<IEnumerable<TimelineEntryResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetTimeline(
+        Guid id,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50)
+    {
+        var kase = await _kases.GetByIdAsync(id);
+        if (kase is null)
+            return NotFound(ApiResponse<IEnumerable<TimelineEntryResponse>>.NotFound(
+                $"Kase with ID '{id}' was not found."));
+
+        var entries = await _kases.GetTimelineAsync(id, Math.Max(1, page), Math.Clamp(pageSize, 1, 200));
+        return Ok(ApiResponse<IEnumerable<TimelineEntryResponse>>.Success(entries));
+    }
 }

--- a/src/KaseLog.Api/Data/ICollectionRepository.cs
+++ b/src/KaseLog.Api/Data/ICollectionRepository.cs
@@ -1,0 +1,58 @@
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+
+namespace KaseLog.Api.Data;
+
+public interface ICollectionRepository
+{
+    // ── Collections ───────────────────────────────────────────────────────────
+    Task<IEnumerable<CollectionResponse>> GetAllAsync();
+    Task<CollectionResponse?> GetByIdAsync(Guid id);
+    Task<CollectionResponse> CreateAsync(CreateCollectionRequest request);
+    Task<CollectionResponse?> UpdateAsync(Guid id, UpdateCollectionRequest request);
+    Task<bool> DeleteAsync(Guid id);
+
+    // ── Fields ────────────────────────────────────────────────────────────────
+    Task<IEnumerable<CollectionFieldResponse>> GetFieldsAsync(Guid collectionId);
+    Task<CollectionFieldResponse> AddFieldAsync(Guid collectionId, CreateCollectionFieldRequest request);
+    Task<CollectionFieldResponse?> UpdateFieldAsync(Guid collectionId, Guid fieldId, UpdateCollectionFieldRequest request);
+    Task<bool> DeleteFieldAsync(Guid collectionId, Guid fieldId);
+
+    /// <summary>
+    /// Updates SortOrder for all fields in collectionId in a single transaction.
+    /// fieldIds must list all field IDs for the collection in the desired order.
+    /// Returns false if the collection does not exist.
+    /// </summary>
+    Task<bool> ReorderFieldsAsync(Guid collectionId, IReadOnlyList<Guid> fieldIds);
+
+    // ── Layout ────────────────────────────────────────────────────────────────
+    Task<CollectionLayoutResponse?> GetLayoutAsync(Guid collectionId);
+    Task<CollectionLayoutResponse> UpsertLayoutAsync(Guid collectionId, string layout);
+
+    // ── Items ─────────────────────────────────────────────────────────────────
+    Task<IEnumerable<CollectionItemResponse>> GetItemsAsync(
+        Guid collectionId,
+        string? q,
+        Guid? kaseId,
+        IReadOnlyDictionary<string, string> fieldFilters,
+        string? sortFieldId,
+        bool sortAsc,
+        int page,
+        int pageSize);
+
+    Task<CollectionItemResponse?> GetItemAsync(Guid id);
+
+    /// <summary>
+    /// Creates a collection item. Throws <see cref="CollectionItemValidationException"/>
+    /// if required fields are missing or empty.
+    /// </summary>
+    Task<CollectionItemResponse> CreateItemAsync(Guid collectionId, CreateCollectionItemRequest request);
+
+    /// <summary>
+    /// Updates a collection item. Throws <see cref="CollectionItemValidationException"/>
+    /// if required fields are missing or empty.
+    /// </summary>
+    Task<CollectionItemResponse?> UpdateItemAsync(Guid id, UpdateCollectionItemRequest request);
+
+    Task<bool> DeleteItemAsync(Guid id);
+}

--- a/src/KaseLog.Api/Data/IKaseRepository.cs
+++ b/src/KaseLog.Api/Data/IKaseRepository.cs
@@ -9,4 +9,9 @@ public interface IKaseRepository
     Task<KaseResponse> CreateAsync(string title, string? description);
     Task<KaseResponse?> UpdateAsync(Guid id, string title, string? description);
     Task<bool> DeleteAsync(Guid id);
+
+    /// <summary>
+    /// Returns logs and linked collection items for a Kase in reverse-chronological order.
+    /// </summary>
+    Task<IEnumerable<TimelineEntryResponse>> GetTimelineAsync(Guid kaseId, int page, int pageSize);
 }

--- a/src/KaseLog.Api/Data/Sqlite/SqliteCollectionRepository.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteCollectionRepository.cs
@@ -1,0 +1,512 @@
+using System.Text;
+using System.Text.Json;
+using Dapper;
+using KaseLog.Api.Models;
+using KaseLog.Api.Models.Requests;
+
+namespace KaseLog.Api.Data.Sqlite;
+
+public sealed class SqliteCollectionRepository : ICollectionRepository
+{
+    private readonly IDbConnectionFactory _db;
+
+    private static readonly HashSet<string> ValidColors =
+        ["teal", "blue", "purple", "coral", "amber"];
+
+    private static readonly HashSet<string> ValidFieldTypes =
+        ["text", "multiline", "number", "date", "select", "rating", "url", "boolean", "image"];
+
+    public SqliteCollectionRepository(IDbConnectionFactory db) => _db = db;
+
+    // ── Collections ───────────────────────────────────────────────────────────
+
+    public async Task<IEnumerable<CollectionResponse>> GetAllAsync()
+    {
+        using var conn = await _db.OpenAsync();
+        var rows = await conn.QueryAsync<CollectionRow>("""
+            SELECT Id, Title, Color, CreatedAt, UpdatedAt
+            FROM Collections
+            ORDER BY UpdatedAt DESC
+            """);
+        return rows.Select(MapCollection);
+    }
+
+    public async Task<CollectionResponse?> GetByIdAsync(Guid id)
+    {
+        using var conn = await _db.OpenAsync();
+        var row = await conn.QuerySingleOrDefaultAsync<CollectionRow>("""
+            SELECT Id, Title, Color, CreatedAt, UpdatedAt
+            FROM Collections WHERE Id = @Id
+            """, new { Id = id.ToString() });
+        return row is null ? null : MapCollection(row);
+    }
+
+    public async Task<CollectionResponse> CreateAsync(CreateCollectionRequest request)
+    {
+        var color = NormalizeColor(request.Color);
+        var id  = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var nowStr = now.ToString("O");
+
+        using var conn = await _db.OpenAsync();
+        await conn.ExecuteAsync("""
+            INSERT INTO Collections(Id, Title, Color, CreatedAt, UpdatedAt)
+            VALUES (@Id, @Title, @Color, @Now, @Now)
+            """,
+            new { Id = id.ToString(), request.Title, Color = color, Now = nowStr });
+
+        return new CollectionResponse
+        {
+            Id        = id,
+            Title     = request.Title,
+            Color     = color,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    public async Task<CollectionResponse?> UpdateAsync(Guid id, UpdateCollectionRequest request)
+    {
+        var color  = NormalizeColor(request.Color);
+        var nowStr = DateTime.UtcNow.ToString("O");
+
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync("""
+            UPDATE Collections SET Title = @Title, Color = @Color, UpdatedAt = @Now
+            WHERE Id = @Id
+            """,
+            new { Id = id.ToString(), request.Title, Color = color, Now = nowStr });
+
+        if (affected == 0) return null;
+        return await GetByIdAsync(id);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id)
+    {
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync(
+            "DELETE FROM Collections WHERE Id = @Id",
+            new { Id = id.ToString() });
+        return affected > 0;
+    }
+
+    // ── Fields ────────────────────────────────────────────────────────────────
+
+    public async Task<IEnumerable<CollectionFieldResponse>> GetFieldsAsync(Guid collectionId)
+    {
+        using var conn = await _db.OpenAsync();
+        var rows = await conn.QueryAsync<FieldRow>("""
+            SELECT Id, CollectionId, Name, Type, Required, ShowInList, Options, SortOrder
+            FROM CollectionFields
+            WHERE CollectionId = @CollectionId
+            ORDER BY SortOrder
+            """, new { CollectionId = collectionId.ToString() });
+        return rows.Select(MapField);
+    }
+
+    public async Task<CollectionFieldResponse> AddFieldAsync(Guid collectionId, CreateCollectionFieldRequest request)
+    {
+        var type = NormalizeFieldType(request.Type);
+        var id   = Guid.NewGuid();
+
+        using var conn = await _db.OpenAsync();
+        await conn.ExecuteAsync("""
+            INSERT INTO CollectionFields(Id, CollectionId, Name, Type, Required, ShowInList, Options, SortOrder)
+            VALUES (@Id, @CollectionId, @Name, @Type, @Required, @ShowInList, @Options, @SortOrder)
+            """,
+            new
+            {
+                Id           = id.ToString(),
+                CollectionId = collectionId.ToString(),
+                request.Name,
+                Type         = type,
+                Required     = request.Required ? 1 : 0,
+                ShowInList   = request.ShowInList ? 1 : 0,
+                Options      = request.Options is null ? null : JsonSerializer.Serialize(request.Options),
+                request.SortOrder,
+            });
+
+        return new CollectionFieldResponse
+        {
+            Id           = id,
+            CollectionId = collectionId,
+            Name         = request.Name,
+            Type         = type,
+            Required     = request.Required,
+            ShowInList   = request.ShowInList,
+            Options      = request.Options,
+            SortOrder    = request.SortOrder,
+        };
+    }
+
+    public async Task<CollectionFieldResponse?> UpdateFieldAsync(
+        Guid collectionId, Guid fieldId, UpdateCollectionFieldRequest request)
+    {
+        var type = NormalizeFieldType(request.Type);
+
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync("""
+            UPDATE CollectionFields
+            SET Name = @Name, Type = @Type, Required = @Required,
+                ShowInList = @ShowInList, Options = @Options
+            WHERE Id = @Id AND CollectionId = @CollectionId
+            """,
+            new
+            {
+                Id           = fieldId.ToString(),
+                CollectionId = collectionId.ToString(),
+                request.Name,
+                Type         = type,
+                Required     = request.Required ? 1 : 0,
+                ShowInList   = request.ShowInList ? 1 : 0,
+                Options      = request.Options is null ? null : JsonSerializer.Serialize(request.Options),
+            });
+
+        if (affected == 0) return null;
+
+        var row = await conn.QuerySingleOrDefaultAsync<FieldRow>("""
+            SELECT Id, CollectionId, Name, Type, Required, ShowInList, Options, SortOrder
+            FROM CollectionFields WHERE Id = @Id
+            """, new { Id = fieldId.ToString() });
+
+        return row is null ? null : MapField(row);
+    }
+
+    public async Task<bool> DeleteFieldAsync(Guid collectionId, Guid fieldId)
+    {
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync(
+            "DELETE FROM CollectionFields WHERE Id = @Id AND CollectionId = @CollectionId",
+            new { Id = fieldId.ToString(), CollectionId = collectionId.ToString() });
+        return affected > 0;
+    }
+
+    public async Task<bool> ReorderFieldsAsync(Guid collectionId, IReadOnlyList<Guid> fieldIds)
+    {
+        using var conn = await _db.OpenAsync();
+
+        // Verify collection exists
+        var exists = await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM Collections WHERE Id = @Id",
+            new { Id = collectionId.ToString() });
+        if (exists == 0) return false;
+
+        using var tx = conn.BeginTransaction();
+        for (var i = 0; i < fieldIds.Count; i++)
+        {
+            await conn.ExecuteAsync(
+                "UPDATE CollectionFields SET SortOrder = @Sort WHERE Id = @Id AND CollectionId = @CollectionId",
+                new { Sort = i, Id = fieldIds[i].ToString(), CollectionId = collectionId.ToString() },
+                tx);
+        }
+        tx.Commit();
+        return true;
+    }
+
+    // ── Layout ────────────────────────────────────────────────────────────────
+
+    public async Task<CollectionLayoutResponse?> GetLayoutAsync(Guid collectionId)
+    {
+        using var conn = await _db.OpenAsync();
+        var layout = await conn.ExecuteScalarAsync<string?>(
+            "SELECT Layout FROM CollectionLayout WHERE CollectionId = @CollectionId",
+            new { CollectionId = collectionId.ToString() });
+        if (layout is null) return null;
+
+        return new CollectionLayoutResponse
+        {
+            CollectionId = collectionId,
+            Layout       = layout,
+        };
+    }
+
+    public async Task<CollectionLayoutResponse> UpsertLayoutAsync(Guid collectionId, string layout)
+    {
+        using var conn = await _db.OpenAsync();
+
+        // Use INSERT OR REPLACE (same effect as ON CONFLICT upsert here since
+        // we always supply all columns; the trigger fires correctly).
+        await conn.ExecuteAsync("""
+            INSERT INTO CollectionLayout(Id, CollectionId, Layout)
+            VALUES (@Id, @CollectionId, @Layout)
+            ON CONFLICT(CollectionId) DO UPDATE SET Layout = excluded.Layout
+            """,
+            new
+            {
+                Id           = Guid.NewGuid().ToString(),
+                CollectionId = collectionId.ToString(),
+                Layout       = layout,
+            });
+
+        return new CollectionLayoutResponse
+        {
+            CollectionId = collectionId,
+            Layout       = layout,
+        };
+    }
+
+    // ── Items ─────────────────────────────────────────────────────────────────
+
+    public async Task<IEnumerable<CollectionItemResponse>> GetItemsAsync(
+        Guid collectionId,
+        string? q,
+        Guid? kaseId,
+        IReadOnlyDictionary<string, string> fieldFilters,
+        string? sortFieldId,
+        bool sortAsc,
+        int page,
+        int pageSize)
+    {
+        using var conn = await _db.OpenAsync();
+
+        var sql = new StringBuilder("""
+            SELECT Id, CollectionId, KaseId, FieldValues, CreatedAt, UpdatedAt
+            FROM CollectionItems
+            WHERE CollectionId = @CollectionId
+            """);
+        var p = new DynamicParameters();
+        p.Add("CollectionId", collectionId.ToString());
+
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            sql.AppendLine(" AND FieldValues LIKE @q");
+            p.Add("q", $"%{q}%");
+        }
+
+        if (kaseId.HasValue)
+        {
+            sql.AppendLine(" AND KaseId = @KaseId");
+            p.Add("KaseId", kaseId.Value.ToString());
+        }
+
+        foreach (var (fieldId, value) in fieldFilters)
+        {
+            // Validate fieldId is a GUID to prevent injection
+            if (!Guid.TryParse(fieldId, out _)) continue;
+            var paramName = $"fv_{fieldId.Replace("-", "")}";
+            sql.AppendLine($" AND json_extract(FieldValues, '$.{fieldId}') = @{paramName}");
+            p.Add(paramName, value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(sortFieldId) && Guid.TryParse(sortFieldId, out _))
+        {
+            var dir = sortAsc ? "ASC" : "DESC";
+            sql.AppendLine($" ORDER BY CAST(json_extract(FieldValues, '$.{sortFieldId}') AS TEXT) {dir}");
+        }
+        else
+        {
+            sql.AppendLine(" ORDER BY CreatedAt DESC");
+        }
+
+        sql.AppendLine(" LIMIT @PageSize OFFSET @Offset");
+        p.Add("PageSize", pageSize);
+        p.Add("Offset", (page - 1) * pageSize);
+
+        var rows = await conn.QueryAsync<ItemRow>(sql.ToString(), p);
+        return rows.Select(MapItem);
+    }
+
+    public async Task<CollectionItemResponse?> GetItemAsync(Guid id)
+    {
+        using var conn = await _db.OpenAsync();
+        var row = await conn.QuerySingleOrDefaultAsync<ItemRow>("""
+            SELECT Id, CollectionId, KaseId, FieldValues, CreatedAt, UpdatedAt
+            FROM CollectionItems WHERE Id = @Id
+            """, new { Id = id.ToString() });
+        return row is null ? null : MapItem(row);
+    }
+
+    public async Task<CollectionItemResponse> CreateItemAsync(
+        Guid collectionId, CreateCollectionItemRequest request)
+    {
+        using var conn = await _db.OpenAsync();
+
+        // Validate required fields
+        await ValidateItemFieldsAsync(conn, collectionId, request.FieldValues);
+
+        var id     = Guid.NewGuid();
+        var now    = DateTime.UtcNow;
+        var nowStr = now.ToString("O");
+        var fieldValuesJson = JsonSerializer.Serialize(request.FieldValues);
+
+        await conn.ExecuteAsync("""
+            INSERT INTO CollectionItems(Id, CollectionId, KaseId, FieldValues, CreatedAt, UpdatedAt)
+            VALUES (@Id, @CollectionId, @KaseId, @FieldValues, @Now, @Now)
+            """,
+            new
+            {
+                Id           = id.ToString(),
+                CollectionId = collectionId.ToString(),
+                KaseId       = request.KaseId?.ToString(),
+                FieldValues  = fieldValuesJson,
+                Now          = nowStr,
+            });
+
+        return new CollectionItemResponse
+        {
+            Id           = id,
+            CollectionId = collectionId,
+            KaseId       = request.KaseId,
+            FieldValues  = JsonDocument.Parse(fieldValuesJson).RootElement.Clone(),
+            CreatedAt    = now,
+            UpdatedAt    = now,
+        };
+    }
+
+    public async Task<CollectionItemResponse?> UpdateItemAsync(
+        Guid id, UpdateCollectionItemRequest request)
+    {
+        using var conn = await _db.OpenAsync();
+
+        // Find the item's collection
+        var collectionIdStr = await conn.ExecuteScalarAsync<string?>(
+            "SELECT CollectionId FROM CollectionItems WHERE Id = @Id",
+            new { Id = id.ToString() });
+        if (collectionIdStr is null) return null;
+
+        var collectionId = Guid.Parse(collectionIdStr);
+
+        // Validate required fields
+        await ValidateItemFieldsAsync(conn, collectionId, request.FieldValues);
+
+        var nowStr          = DateTime.UtcNow.ToString("O");
+        var fieldValuesJson = JsonSerializer.Serialize(request.FieldValues);
+
+        var affected = await conn.ExecuteAsync("""
+            UPDATE CollectionItems
+            SET KaseId = @KaseId, FieldValues = @FieldValues, UpdatedAt = @Now
+            WHERE Id = @Id
+            """,
+            new
+            {
+                Id          = id.ToString(),
+                KaseId      = request.KaseId?.ToString(),
+                FieldValues = fieldValuesJson,
+                Now         = nowStr,
+            });
+
+        if (affected == 0) return null;
+        return await GetItemAsync(id);
+    }
+
+    public async Task<bool> DeleteItemAsync(Guid id)
+    {
+        using var conn = await _db.OpenAsync();
+        var affected = await conn.ExecuteAsync(
+            "DELETE FROM CollectionItems WHERE Id = @Id",
+            new { Id = id.ToString() });
+        return affected > 0;
+    }
+
+    // ── Validation helpers ────────────────────────────────────────────────────
+
+    private static async Task ValidateItemFieldsAsync(
+        System.Data.IDbConnection conn,
+        Guid collectionId,
+        Dictionary<string, JsonElement> fieldValues)
+    {
+        var requiredFields = await conn.QueryAsync<(string Id, string Name)>("""
+            SELECT Id, Name FROM CollectionFields
+            WHERE CollectionId = @CollectionId AND Required = 1
+            """, new { CollectionId = collectionId.ToString() });
+
+        var errors = new Dictionary<string, string[]>();
+        foreach (var (fieldId, fieldName) in requiredFields)
+        {
+            var missing = !fieldValues.TryGetValue(fieldId, out var element);
+            var blank   = !missing && IsBlankElement(element);
+            if (missing || blank)
+                errors[fieldId] = [$"'{fieldName}' is required."];
+        }
+
+        if (errors.Count > 0)
+            throw new CollectionItemValidationException(errors);
+    }
+
+    private static bool IsBlankElement(JsonElement element)
+        => element.ValueKind switch
+        {
+            JsonValueKind.Null      => true,
+            JsonValueKind.Undefined => true,
+            JsonValueKind.String    => string.IsNullOrWhiteSpace(element.GetString()),
+            _                       => false,
+        };
+
+    // ── Mapping ───────────────────────────────────────────────────────────────
+
+    private static CollectionResponse MapCollection(CollectionRow r) => new()
+    {
+        Id        = Guid.Parse(r.Id),
+        Title     = r.Title,
+        Color     = r.Color,
+        CreatedAt = DateTime.Parse(r.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+        UpdatedAt = DateTime.Parse(r.UpdatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+    };
+
+    private static CollectionFieldResponse MapField(FieldRow r) => new()
+    {
+        Id           = Guid.Parse(r.Id),
+        CollectionId = Guid.Parse(r.CollectionId),
+        Name         = r.Name,
+        Type         = r.Type,
+        Required     = r.Required != 0,
+        ShowInList   = r.ShowInList != 0,
+        Options      = r.Options is null ? null : JsonSerializer.Deserialize<string[]>(r.Options),
+        SortOrder    = r.SortOrder,
+    };
+
+    private static CollectionItemResponse MapItem(ItemRow r) => new()
+    {
+        Id           = Guid.Parse(r.Id),
+        CollectionId = Guid.Parse(r.CollectionId),
+        KaseId       = r.KaseId is null ? null : Guid.Parse(r.KaseId),
+        FieldValues  = JsonDocument.Parse(r.FieldValues).RootElement.Clone(),
+        CreatedAt    = DateTime.Parse(r.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+        UpdatedAt    = DateTime.Parse(r.UpdatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+    };
+
+    private static string NormalizeColor(string color)
+    {
+        var lower = color.Trim().ToLowerInvariant();
+        return ValidColors.Contains(lower) ? lower : "teal";
+    }
+
+    private static string NormalizeFieldType(string type)
+    {
+        var lower = type.Trim().ToLowerInvariant();
+        return ValidFieldTypes.Contains(lower) ? lower : type.ToLowerInvariant();
+    }
+
+    // ── Row types ─────────────────────────────────────────────────────────────
+
+    private sealed class CollectionRow
+    {
+        public string Id        { get; set; } = string.Empty;
+        public string Title     { get; set; } = string.Empty;
+        public string Color     { get; set; } = "teal";
+        public string CreatedAt { get; set; } = string.Empty;
+        public string UpdatedAt { get; set; } = string.Empty;
+    }
+
+    private sealed class FieldRow
+    {
+        public string  Id           { get; set; } = string.Empty;
+        public string  CollectionId { get; set; } = string.Empty;
+        public string  Name         { get; set; } = string.Empty;
+        public string  Type         { get; set; } = string.Empty;
+        public int     Required     { get; set; }
+        public int     ShowInList   { get; set; }
+        public string? Options      { get; set; }
+        public int     SortOrder    { get; set; }
+    }
+
+    private sealed class ItemRow
+    {
+        public string  Id           { get; set; } = string.Empty;
+        public string  CollectionId { get; set; } = string.Empty;
+        public string? KaseId       { get; set; }
+        public string  FieldValues  { get; set; } = "{}";
+        public string  CreatedAt    { get; set; } = string.Empty;
+        public string  UpdatedAt    { get; set; } = string.Empty;
+    }
+}

--- a/src/KaseLog.Api/Data/Sqlite/SqliteKaseRepository.cs
+++ b/src/KaseLog.Api/Data/Sqlite/SqliteKaseRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Dapper;
 using KaseLog.Api.Models;
 
@@ -84,6 +85,113 @@ public sealed class SqliteKaseRepository : IKaseRepository
             "DELETE FROM Kases WHERE Id = @Id",
             new { Id = id.ToString() });
         return affected > 0;
+    }
+
+    public async Task<IEnumerable<TimelineEntryResponse>> GetTimelineAsync(Guid kaseId, int page, int pageSize)
+    {
+        using var conn = await _db.OpenAsync();
+
+        var rows = await conn.QueryAsync<TimelineRow>("""
+            SELECT
+                'log'             AS EntityType,
+                l.Id              AS Id,
+                l.CreatedAt       AS CreatedAt,
+                l.Title           AS Title,
+                l.Description     AS Description,
+                (SELECT COUNT(*) FROM LogVersions WHERE LogId = l.Id) AS VersionCount,
+                NULL              AS CollectionId,
+                NULL              AS CollectionTitle,
+                NULL              AS CollectionColor,
+                NULL              AS FieldValues
+            FROM Logs l
+            WHERE l.KaseId = @KaseId
+            UNION ALL
+            SELECT
+                'collection_item' AS EntityType,
+                ci.Id             AS Id,
+                ci.CreatedAt      AS CreatedAt,
+                NULL              AS Title,
+                NULL              AS Description,
+                0                 AS VersionCount,
+                ci.CollectionId   AS CollectionId,
+                c.Title           AS CollectionTitle,
+                c.Color           AS CollectionColor,
+                ci.FieldValues    AS FieldValues
+            FROM CollectionItems ci
+            JOIN Collections c ON c.Id = ci.CollectionId
+            WHERE ci.KaseId = @KaseId
+            ORDER BY CreatedAt DESC
+            LIMIT @PageSize OFFSET @Offset
+            """,
+            new { KaseId = kaseId.ToString(), PageSize = pageSize, Offset = (page - 1) * pageSize });
+
+        var rowList = rows.ToList();
+
+        // Fetch tags for any logs in the result
+        var logIds = rowList
+            .Where(r => r.EntityType == "log")
+            .Select(r => r.Id)
+            .ToList();
+
+        Dictionary<string, List<string>> tagMap = [];
+        if (logIds.Count > 0)
+        {
+            var tagRows = await conn.QueryAsync<(string LogId, string Name)>("""
+                SELECT lt.LogId, t.Name
+                FROM LogTags lt
+                JOIN Tags t ON t.Id = lt.TagId
+                WHERE lt.LogId IN @LogIds
+                ORDER BY t.Name
+                """, new { LogIds = logIds });
+
+            foreach (var (logId, name) in tagRows)
+            {
+                if (!tagMap.TryGetValue(logId, out var list))
+                {
+                    list = [];
+                    tagMap[logId] = list;
+                }
+                list.Add(name);
+            }
+        }
+
+        return rowList.Select(r => r.EntityType == "log"
+            ? new TimelineEntryResponse
+            {
+                EntityType   = "log",
+                Id           = Guid.Parse(r.Id),
+                CreatedAt    = DateTime.Parse(r.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+                Title        = r.Title,
+                Description  = r.Description,
+                VersionCount = (int)r.VersionCount,
+                Tags         = tagMap.TryGetValue(r.Id, out var t) ? t : [],
+            }
+            : new TimelineEntryResponse
+            {
+                EntityType       = "collection_item",
+                Id               = Guid.Parse(r.Id),
+                CreatedAt        = DateTime.Parse(r.CreatedAt, null, System.Globalization.DateTimeStyles.RoundtripKind),
+                CollectionId     = r.CollectionId is null ? null : Guid.Parse(r.CollectionId),
+                CollectionTitle  = r.CollectionTitle,
+                CollectionColor  = r.CollectionColor,
+                FieldValues      = r.FieldValues is null
+                    ? null
+                    : JsonDocument.Parse(r.FieldValues).RootElement.Clone(),
+            });
+    }
+
+    private sealed class TimelineRow
+    {
+        public string EntityType { get; set; } = string.Empty;
+        public string Id { get; set; } = string.Empty;
+        public string CreatedAt { get; set; } = string.Empty;
+        public string? Title { get; set; }
+        public string? Description { get; set; }
+        public long VersionCount { get; set; }
+        public string? CollectionId { get; set; }
+        public string? CollectionTitle { get; set; }
+        public string? CollectionColor { get; set; }
+        public string? FieldValues { get; set; }
     }
 
     private static KaseResponse Map(KaseRow row) => new()

--- a/src/KaseLog.Api/Models/CollectionFieldResponse.cs
+++ b/src/KaseLog.Api/Models/CollectionFieldResponse.cs
@@ -1,0 +1,13 @@
+namespace KaseLog.Api.Models;
+
+public sealed class CollectionFieldResponse
+{
+    public required Guid Id { get; init; }
+    public required Guid CollectionId { get; init; }
+    public required string Name { get; init; }
+    public required string Type { get; init; }
+    public required bool Required { get; init; }
+    public required bool ShowInList { get; init; }
+    public string[]? Options { get; init; }
+    public required int SortOrder { get; init; }
+}

--- a/src/KaseLog.Api/Models/CollectionItemResponse.cs
+++ b/src/KaseLog.Api/Models/CollectionItemResponse.cs
@@ -1,0 +1,13 @@
+using System.Text.Json;
+
+namespace KaseLog.Api.Models;
+
+public sealed class CollectionItemResponse
+{
+    public required Guid Id { get; init; }
+    public required Guid CollectionId { get; init; }
+    public Guid? KaseId { get; init; }
+    public required JsonElement FieldValues { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public required DateTime UpdatedAt { get; init; }
+}

--- a/src/KaseLog.Api/Models/CollectionItemValidationException.cs
+++ b/src/KaseLog.Api/Models/CollectionItemValidationException.cs
@@ -1,0 +1,12 @@
+namespace KaseLog.Api.Models;
+
+public sealed class CollectionItemValidationException : Exception
+{
+    public IReadOnlyDictionary<string, string[]> FieldErrors { get; }
+
+    public CollectionItemValidationException(IReadOnlyDictionary<string, string[]> fieldErrors)
+        : base("One or more required fields are missing or empty.")
+    {
+        FieldErrors = fieldErrors;
+    }
+}

--- a/src/KaseLog.Api/Models/CollectionLayoutResponse.cs
+++ b/src/KaseLog.Api/Models/CollectionLayoutResponse.cs
@@ -1,0 +1,7 @@
+namespace KaseLog.Api.Models;
+
+public sealed class CollectionLayoutResponse
+{
+    public required Guid CollectionId { get; init; }
+    public required string Layout { get; init; }
+}

--- a/src/KaseLog.Api/Models/CollectionResponse.cs
+++ b/src/KaseLog.Api/Models/CollectionResponse.cs
@@ -1,0 +1,10 @@
+namespace KaseLog.Api.Models;
+
+public sealed class CollectionResponse
+{
+    public required Guid Id { get; init; }
+    public required string Title { get; init; }
+    public required string Color { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public required DateTime UpdatedAt { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/CreateCollectionFieldRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/CreateCollectionFieldRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class CreateCollectionFieldRequest
+{
+    [Required, MaxLength(100)]
+    public required string Name { get; init; }
+
+    [Required]
+    public required string Type { get; init; }
+
+    public bool Required { get; init; }
+    public bool ShowInList { get; init; } = true;
+    public string[]? Options { get; init; }
+    public int SortOrder { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/CreateCollectionItemRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/CreateCollectionItemRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class CreateCollectionItemRequest
+{
+    public Guid? KaseId { get; init; }
+
+    [Required]
+    public required Dictionary<string, JsonElement> FieldValues { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/CreateCollectionRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/CreateCollectionRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class CreateCollectionRequest
+{
+    [Required, MaxLength(200)]
+    public required string Title { get; init; }
+
+    public string Color { get; init; } = "teal";
+}

--- a/src/KaseLog.Api/Models/Requests/ReorderFieldsRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/ReorderFieldsRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class ReorderFieldsRequest
+{
+    [Required]
+    public required IReadOnlyList<Guid> FieldIds { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/UpdateCollectionFieldRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/UpdateCollectionFieldRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class UpdateCollectionFieldRequest
+{
+    [Required, MaxLength(100)]
+    public required string Name { get; init; }
+
+    [Required]
+    public required string Type { get; init; }
+
+    public bool Required { get; init; }
+    public bool ShowInList { get; init; } = true;
+    public string[]? Options { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/UpdateCollectionItemRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/UpdateCollectionItemRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class UpdateCollectionItemRequest
+{
+    public Guid? KaseId { get; init; }
+
+    [Required]
+    public required Dictionary<string, JsonElement> FieldValues { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/UpdateCollectionLayoutRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/UpdateCollectionLayoutRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class UpdateCollectionLayoutRequest
+{
+    [Required]
+    public required string Layout { get; init; }
+}

--- a/src/KaseLog.Api/Models/Requests/UpdateCollectionRequest.cs
+++ b/src/KaseLog.Api/Models/Requests/UpdateCollectionRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KaseLog.Api.Models.Requests;
+
+public sealed class UpdateCollectionRequest
+{
+    [Required, MaxLength(200)]
+    public required string Title { get; init; }
+
+    public string Color { get; init; } = "teal";
+}

--- a/src/KaseLog.Api/Models/TimelineEntryResponse.cs
+++ b/src/KaseLog.Api/Models/TimelineEntryResponse.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+
+namespace KaseLog.Api.Models;
+
+public sealed class TimelineEntryResponse
+{
+    // ── Common ────────────────────────────────────────────────────────────────
+    public required string EntityType { get; init; }
+    public required Guid Id { get; init; }
+    public required DateTime CreatedAt { get; init; }
+
+    // ── Log-specific (null for collection_item) ───────────────────────────────
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+    public int? VersionCount { get; init; }
+    public IReadOnlyList<string>? Tags { get; init; }
+
+    // ── Collection item-specific (null for log) ───────────────────────────────
+    public Guid? CollectionId { get; init; }
+    public string? CollectionTitle { get; init; }
+    public string? CollectionColor { get; init; }
+    public JsonElement? FieldValues { get; init; }
+}

--- a/src/KaseLog.Api/Program.cs
+++ b/src/KaseLog.Api/Program.cs
@@ -33,6 +33,7 @@ if (dbProvider.Equals("sqlite", StringComparison.OrdinalIgnoreCase))
     builder.Services.AddScoped<ITagRepository, SqliteTagRepository>();
     builder.Services.AddScoped<ISearchRepository, SqliteSearchRepository>();
     builder.Services.AddScoped<IUserRepository, SqliteUserRepository>();
+    builder.Services.AddScoped<ICollectionRepository, SqliteCollectionRepository>();
 }
 else
 {

--- a/tests/KaseLog.Api.Tests/Controllers/CollectionsControllerTests.cs
+++ b/tests/KaseLog.Api.Tests/Controllers/CollectionsControllerTests.cs
@@ -1,0 +1,434 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Dapper;
+using KaseLog.Api.Data;
+using KaseLog.Api.Data.Sqlite;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace KaseLog.Api.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for the Collections API.
+/// Each test gets an isolated named in-memory SQLite database.
+/// </summary>
+public sealed class CollectionsControllerTests : IAsyncLifetime
+{
+    private readonly string _dbName;
+    private string _testConnString = null!;
+    private SqliteConnection _keepAlive = null!;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public CollectionsControllerTests()
+    {
+        _dbName = $"CollectionsTest_{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        _testConnString = $"Data Source={_dbName};Mode=Memory;Cache=Shared";
+        _keepAlive      = new SqliteConnection(_testConnString);
+        await _keepAlive.OpenAsync();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), _dbName);
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH",
+            Path.Combine(tempDir, "kaselog.db"));
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IDbConnectionFactory));
+                    if (descriptor is not null) services.Remove(descriptor);
+
+                    services.AddSingleton<IDbConnectionFactory>(
+                        new SqliteConnectionFactory(_testConnString));
+                });
+            });
+
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH", null);
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _keepAlive.DisposeAsync();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<JsonElement> PostCollectionAsync(string title, string color = "teal")
+    {
+        var response = await _client.PostAsJsonAsync("/api/collections", new { title, color });
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+    }
+
+    private async Task<JsonElement> PostFieldAsync(string collectionId, string name,
+        string type = "text", bool required = false, int sortOrder = 0)
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/collections/{collectionId}/fields",
+            new { name, type, required, showInList = true, sortOrder });
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+    }
+
+    private async Task<JsonElement> PostKaseAsync(string title)
+    {
+        var response = await _client.PostAsJsonAsync("/api/kases", new { title });
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+    }
+
+    private async Task InsertLogVersionAsync(string logId, string content)
+    {
+        await using var conn = new SqliteConnection(_testConnString);
+        await conn.OpenAsync();
+        await conn.ExecuteAsync("PRAGMA foreign_keys=ON;");
+        await conn.ExecuteAsync(
+            "INSERT INTO LogVersions(Id, LogId, Content, IsAutosave, CreatedAt) VALUES (@Id, @LogId, @Content, 1, @Now)",
+            new { Id = Guid.NewGuid().ToString(), LogId = logId, Content = content, Now = DateTime.UtcNow.ToString("O") });
+    }
+
+    private async Task InsertLogAsync(string kaseId, string title = "Test Log")
+    {
+        await using var conn = new SqliteConnection(_testConnString);
+        await conn.OpenAsync();
+        await conn.ExecuteAsync("PRAGMA foreign_keys=ON;");
+        var now = DateTime.UtcNow.ToString("O");
+        await conn.ExecuteAsync(
+            "INSERT INTO Logs(Id, KaseId, Title, AutosaveEnabled, CreatedAt, UpdatedAt) VALUES (@Id, @KaseId, @Title, 1, @Now, @Now)",
+            new { Id = Guid.NewGuid().ToString(), KaseId = kaseId, Title = title, Now = now });
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetCollections_EmptyDatabase_ReturnsEmptyList()
+    {
+        var response = await _client.GetAsync("/api/collections");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("data").ValueKind);
+        Assert.Equal(0, root.GetProperty("data").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task PostCollection_ValidRequest_CreatesCollectionWithCorrectFields()
+    {
+        var response = await _client.PostAsJsonAsync("/api/collections",
+            new { title = "My Gear", color = "blue" });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        var data = root.GetProperty("data");
+
+        Assert.NotEqual(Guid.Empty, Guid.Parse(data.GetProperty("id").GetString()!));
+        Assert.Equal("My Gear", data.GetProperty("title").GetString());
+        Assert.Equal("blue", data.GetProperty("color").GetString());
+        Assert.NotEmpty(data.GetProperty("createdAt").GetString()!);
+        Assert.NotEmpty(data.GetProperty("updatedAt").GetString()!);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("error").ValueKind);
+    }
+
+    [Fact]
+    public async Task GetCollection_UnknownId_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/collections/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostField_AddsFieldWithCorrectSortOrder()
+    {
+        var col   = await PostCollectionAsync("Books");
+        var colId = col.GetProperty("id").GetString()!;
+
+        var field = await PostFieldAsync(colId, "Title", "text", sortOrder: 3);
+
+        Assert.Equal("Title",  field.GetProperty("name").GetString());
+        Assert.Equal("text",   field.GetProperty("type").GetString());
+        Assert.Equal(3,        field.GetProperty("sortOrder").GetInt32());
+        Assert.Equal(colId,    field.GetProperty("collectionId").GetString());
+    }
+
+    [Fact]
+    public async Task PutFieldsReorder_UpdatesAllSortOrders()
+    {
+        var col   = await PostCollectionAsync("Movies");
+        var colId = col.GetProperty("id").GetString()!;
+
+        var fieldA = await PostFieldAsync(colId, "A", sortOrder: 0);
+        var fieldB = await PostFieldAsync(colId, "B", sortOrder: 1);
+        var fieldC = await PostFieldAsync(colId, "C", sortOrder: 2);
+
+        var idA = fieldA.GetProperty("id").GetString()!;
+        var idB = fieldB.GetProperty("id").GetString()!;
+        var idC = fieldC.GetProperty("id").GetString()!;
+
+        // Reverse the order: C, B, A
+        var reorderResponse = await _client.PutAsJsonAsync(
+            $"/api/collections/{colId}/fields/reorder",
+            new { fieldIds = new[] { idC, idB, idA } });
+
+        Assert.Equal(HttpStatusCode.OK, reorderResponse.StatusCode);
+
+        var getResponse = await _client.GetAsync($"/api/collections/{colId}/fields");
+        var fields = JsonDocument.Parse(await getResponse.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+
+        Assert.Equal(idC, fields[0].GetProperty("id").GetString());
+        Assert.Equal(0,   fields[0].GetProperty("sortOrder").GetInt32());
+        Assert.Equal(idB, fields[1].GetProperty("id").GetString());
+        Assert.Equal(1,   fields[1].GetProperty("sortOrder").GetInt32());
+        Assert.Equal(idA, fields[2].GetProperty("id").GetString());
+        Assert.Equal(2,   fields[2].GetProperty("sortOrder").GetInt32());
+    }
+
+    [Fact]
+    public async Task PutLayout_StoresLayoutJsonAndRetrievesItUnchanged()
+    {
+        var col   = await PostCollectionAsync("Vinyl");
+        var colId = col.GetProperty("id").GetString()!;
+
+        var layout = """[{"cells":[{"kind":"field","fieldId":"abc","span":2},null]}]""";
+
+        var putResponse = await _client.PutAsJsonAsync(
+            $"/api/collections/{colId}/layout",
+            new { layout });
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        var getResponse = await _client.GetAsync($"/api/collections/{colId}/layout");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var returned = JsonDocument.Parse(await getResponse.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data").GetProperty("layout").GetString();
+
+        Assert.Equal(layout, returned);
+    }
+
+    [Fact]
+    public async Task PostItem_MissingRequiredField_Returns400()
+    {
+        var col   = await PostCollectionAsync("Albums");
+        var colId = col.GetProperty("id").GetString()!;
+
+        // Add a required field
+        await PostFieldAsync(colId, "Artist", "text", required: true, sortOrder: 0);
+
+        // Post item without the required field
+        var response = await _client.PostAsJsonAsync(
+            $"/api/collections/{colId}/items",
+            new { fieldValues = new { } });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("data").ValueKind);
+        Assert.Equal(400, root.GetProperty("error").GetProperty("status").GetInt32());
+    }
+
+    [Fact]
+    public async Task PostItem_ValidData_CreatesItemAndIndexesInFts5()
+    {
+        var col     = await PostCollectionAsync("Films");
+        var colId   = col.GetProperty("id").GetString()!;
+        var field   = await PostFieldAsync(colId, "Title", "text", sortOrder: 0);
+        var fieldId = field.GetProperty("id").GetString()!;
+
+        var fieldValues = new Dictionary<string, string> { [fieldId] = "Blade Runner" };
+        var response = await _client.PostAsJsonAsync(
+            $"/api/collections/{colId}/items",
+            new { fieldValues });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var data   = JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+        var itemId = data.GetProperty("id").GetString()!;
+
+        // Verify FTS5 entry
+        await using var conn = new SqliteConnection(_testConnString);
+        await conn.OpenAsync();
+        var entityType = await conn.ExecuteScalarAsync<string>(
+            "SELECT entity_type FROM kaselog_search WHERE entity_id = @Id",
+            new { Id = itemId });
+
+        Assert.Equal("collection_item", entityType);
+    }
+
+    [Fact]
+    public async Task GetItems_WithFieldFilter_ReturnsMatchingItemsOnly()
+    {
+        var col     = await PostCollectionAsync("Books");
+        var colId   = col.GetProperty("id").GetString()!;
+        var field   = await PostFieldAsync(colId, "Genre", "select", sortOrder: 0);
+        var fieldId = field.GetProperty("id").GetString()!;
+
+        // Create two items with different genres
+        await _client.PostAsJsonAsync($"/api/collections/{colId}/items",
+            new { fieldValues = new Dictionary<string, string> { [fieldId] = "Fiction" } });
+        await _client.PostAsJsonAsync($"/api/collections/{colId}/items",
+            new { fieldValues = new Dictionary<string, string> { [fieldId] = "Non-Fiction" } });
+
+        // Filter by Genre=Fiction
+        var response = await _client.GetAsync(
+            $"/api/collections/{colId}/items?field[{fieldId}]=Fiction");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var items = JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+
+        Assert.Equal(1, items.GetArrayLength());
+        var returned = items[0].GetProperty("fieldValues");
+        Assert.Equal("Fiction", returned.GetProperty(fieldId).GetString());
+    }
+
+    [Fact]
+    public async Task GetTimeline_ReturnsMixedEntriesWithCorrectEntityType()
+    {
+        var kase   = await PostKaseAsync("Incident Alpha");
+        var kaseId = kase.GetProperty("id").GetString()!;
+
+        // Add a log
+        await InsertLogAsync(kaseId, "First Log");
+
+        // Add a collection item linked to the kase
+        var col     = await PostCollectionAsync("Items");
+        var colId   = col.GetProperty("id").GetString()!;
+        var field   = await PostFieldAsync(colId, "Name", "text");
+        var fieldId = field.GetProperty("id").GetString()!;
+
+        await _client.PostAsJsonAsync($"/api/collections/{colId}/items",
+            new
+            {
+                kaseId,
+                fieldValues = new Dictionary<string, string> { [fieldId] = "Widget" },
+            });
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/timeline");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var entries = JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+
+        Assert.True(entries.GetArrayLength() >= 2);
+
+        var entityTypes = Enumerable.Range(0, entries.GetArrayLength())
+            .Select(i => entries[i].GetProperty("entityType").GetString())
+            .ToHashSet();
+
+        Assert.Contains("log",             entityTypes);
+        Assert.Contains("collection_item", entityTypes);
+    }
+
+    [Fact]
+    public async Task GetTimeline_EntriesAreInReverseChronologicalOrder()
+    {
+        var kase   = await PostKaseAsync("Order Test");
+        var kaseId = kase.GetProperty("id").GetString()!;
+
+        // Insert log first
+        await InsertLogAsync(kaseId, "Log A");
+        await Task.Delay(10);
+
+        // Insert collection item second
+        var col     = await PostCollectionAsync("Things");
+        var colId   = col.GetProperty("id").GetString()!;
+        var field   = await PostFieldAsync(colId, "Name", "text");
+        var fieldId = field.GetProperty("id").GetString()!;
+
+        await _client.PostAsJsonAsync($"/api/collections/{colId}/items",
+            new { kaseId, fieldValues = new Dictionary<string, string> { [fieldId] = "Item B" } });
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/timeline");
+        var entries  = JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data");
+
+        Assert.True(entries.GetArrayLength() >= 2);
+
+        // First entry should be newer (collection_item inserted after log)
+        var first  = DateTime.Parse(entries[0].GetProperty("createdAt").GetString()!);
+        var second = DateTime.Parse(entries[1].GetProperty("createdAt").GetString()!);
+        Assert.True(first >= second, "Timeline should be in reverse-chronological order");
+    }
+
+    [Fact]
+    public async Task DeleteCollection_RemovesCollectionFieldsLayoutAndItems()
+    {
+        var col   = await PostCollectionAsync("To Delete");
+        var colId = col.GetProperty("id").GetString()!;
+
+        await PostFieldAsync(colId, "Name", "text");
+        await _client.PutAsJsonAsync($"/api/collections/{colId}/layout",
+            new { layout = "[]" });
+        await _client.PostAsJsonAsync($"/api/collections/{colId}/items",
+            new { fieldValues = new { } });
+
+        var deleteResponse = await _client.DeleteAsync($"/api/collections/{colId}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        // Collection is gone
+        var getResponse = await _client.GetAsync($"/api/collections/{colId}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+
+        // Verify DB cascade via direct query
+        await using var conn = new SqliteConnection(_testConnString);
+        await conn.OpenAsync();
+
+        Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM CollectionFields WHERE CollectionId = @Id", new { Id = colId }));
+        Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM CollectionLayout WHERE CollectionId = @Id", new { Id = colId }));
+        Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM CollectionItems WHERE CollectionId = @Id", new { Id = colId }));
+    }
+
+    [Fact]
+    public async Task DeleteItem_RemovesFts5Entry()
+    {
+        var col     = await PostCollectionAsync("Stamps");
+        var colId   = col.GetProperty("id").GetString()!;
+        var field   = await PostFieldAsync(colId, "Name", "text");
+        var fieldId = field.GetProperty("id").GetString()!;
+
+        var createResponse = await _client.PostAsJsonAsync($"/api/collections/{colId}/items",
+            new { fieldValues = new Dictionary<string, string> { [fieldId] = "Penny Black" } });
+        var itemId = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("data").GetProperty("id").GetString()!;
+
+        // Confirm FTS entry exists
+        await using var conn = new SqliteConnection(_testConnString);
+        await conn.OpenAsync();
+        Assert.Equal(1L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM kaselog_search WHERE entity_id = @Id AND entity_type = 'collection_item'",
+            new { Id = itemId }));
+
+        var deleteResponse = await _client.DeleteAsync($"/api/items/{itemId}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        Assert.Equal(0L, await conn.ExecuteScalarAsync<long>(
+            "SELECT count(*) FROM kaselog_search WHERE entity_id = @Id AND entity_type = 'collection_item'",
+            new { Id = itemId }));
+    }
+}


### PR DESCRIPTION
## Summary

Implements all Collections API endpoints from AGENTS.md on top of the schema in #18.

**New endpoints:**
- `GET/POST /api/collections` — list all, create
- `GET/PUT/DELETE /api/collections/{id}` — get, update, delete
- `GET/POST /api/collections/{id}/fields` — list fields, add field
- `PUT /api/collections/{id}/fields/{fieldId}` / `DELETE` — update / delete field
- `PUT /api/collections/{id}/fields/reorder` — atomically reorders all SortOrder values in a transaction
- `GET/PUT /api/collections/{id}/layout` — get layout (returns `[]` if none), atomic full-replace upsert
- `GET /api/collections/{id}/items` — list items with `q`, `kaseId`, `field[fieldId]=value`, `sort`, `dir`, `page`, `pageSize`
- `POST /api/collections/{id}/items` — create item, validates required fields → 400 with field-level errors
- `GET/PUT/DELETE /api/items/{id}` — individual item management
- `GET /api/kases/{id}/timeline` — UNION ALL of Logs + CollectionItems linked to Kase, reverse-chrono, paginated

**Validation:**
- Collection color: must be `teal`, `blue`, `purple`, `coral`, `amber`
- Field type: must be one of the 9 AGENTS.md types
- CollectionItem: required fields checked against schema on create/update; returns 400 with `{ fieldId: ["error"] }` map

## Test plan

- [ ] All 59 tests pass (`dotnet test tests/KaseLog.Api.Tests`)
- [ ] `GetCollections_EmptyDatabase_ReturnsEmptyList`
- [ ] `PostCollection_ValidRequest_CreatesCollectionWithCorrectFields`
- [ ] `GetCollection_UnknownId_Returns404`
- [ ] `PostField_AddsFieldWithCorrectSortOrder`
- [ ] `PutFieldsReorder_UpdatesAllSortOrders`
- [ ] `PutLayout_StoresLayoutJsonAndRetrievesItUnchanged`
- [ ] `PostItem_MissingRequiredField_Returns400`
- [ ] `PostItem_ValidData_CreatesItemAndIndexesInFts5`
- [ ] `GetItems_WithFieldFilter_ReturnsMatchingItemsOnly`
- [ ] `GetTimeline_ReturnsMixedEntriesWithCorrectEntityType`
- [ ] `GetTimeline_EntriesAreInReverseChronologicalOrder`
- [ ] `DeleteCollection_RemovesCollectionFieldsLayoutAndItems`
- [ ] `DeleteItem_RemovesFts5Entry`
- [ ] `docker build -f docker/Dockerfile -t docker-kaselog .` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)