### PR TITLE
fix: add cache: no-store to API request helper

### DIFF
--- a/src/kaselog-ui/src/api/client.ts
+++ b/src/kaselog-ui/src/api/client.ts
@@ -25,6 +25,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   try {
     res = await fetch(path, {
       headers: { 'Content-Type': 'application/json', ...options?.headers },
+      cache: 'no-store',
       ...options,
     })
   } catch {


### PR DESCRIPTION
## Summary

- Adds `cache: 'no-store'` to all `fetch` calls in the API request helper
- Prevents the browser from serving stale cached responses when the backend changes (e.g. proxy target switching in dev, or during redeployment)
- API responses for a data-driven app should never be served from the HTTP cache

## Test plan

- [ ] 91 frontend tests pass (`npm test` in `src/kaselog-ui`)
- [ ] API calls in the running app return fresh data on every request

🤖 Generated with [Claude Code](https://claude.com/claude-code)