### PR TITLE
fix: add cache: no-store to API request helper

### DIFF
--- a/src/kaselog-ui/src/api/client.ts
+++ b/src/kaselog-ui/src/api/client.ts
@@ -25,6 +25,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   try {
     res = await fetch(path, {
       headers: { 'Content-Type': 'application/json', ...options?.headers },
+      cache: 'no-store',
       ...options,
     })
   } catch {


### PR DESCRIPTION
Adds cache: no-store to API request helper to prevent stale data issues.