### PR TITLE
feat: export Kase as Markdown or PDF

### DIFF
--- a/src/KaseLog.Api/Controllers/KasesController.cs
+++ b/src/KaseLog.Api/Controllers/KasesController.cs
@@ -1,6 +1,7 @@
 using KaseLog.Api.Data;
 using KaseLog.Api.Models;
 using KaseLog.Api.Models.Requests;
+using KaseLog.Api.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace KaseLog.Api.Controllers;
@@ -12,12 +13,14 @@ namespace KaseLog.Api.Controllers;
 public sealed class KasesController : ControllerBase
 {
     private readonly IKaseRepository _kases;
+    private readonly IKaseExportService _export;
     private readonly ILogger<KasesController> _logger;
 
     /// <summary>Initialises a new instance of <see cref="KasesController"/>.</summary>
-    public KasesController(IKaseRepository kases, ILogger<KasesController> logger)
+    public KasesController(IKaseRepository kases, IKaseExportService export, ILogger<KasesController> logger)
     {
         _kases  = kases;
+        _export = export;
         _logger = logger;
     }
 
@@ -133,5 +136,37 @@ public sealed class KasesController : ControllerBase
 
         var entries = await _kases.GetTimelineAsync(id, Math.Max(1, page), Math.Clamp(pageSize, 1, 200));
         return Ok(ApiResponse<IEnumerable<TimelineEntryResponse>>.Success(entries));
+    }
+
+    /// <summary>Exports a Kase as a Markdown or PDF file download.</summary>
+    /// <param name="id">The GUID of the Kase to export.</param>
+    /// <param name="format">Export format: <c>markdown</c> or <c>pdf</c>.</param>
+    /// <returns>The file as a download, or 404 if the Kase is not found.</returns>
+    [HttpGet("{id:guid}/export")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Export(Guid id, [FromQuery] string format = "markdown")
+    {
+        var fmt = format.ToLowerInvariant();
+
+        if (fmt != "markdown" && fmt != "pdf")
+        {
+            return BadRequest(ApiResponse<object>.Failure(
+                "https://tools.ietf.org/html/rfc7807",
+                "Bad Request", 400,
+                "Invalid format. Supported values: markdown, pdf."));
+        }
+
+        var result = fmt == "pdf"
+            ? await _export.ExportPdfAsync(id)
+            : await _export.ExportMarkdownAsync(id);
+
+        if (result is null)
+            return NotFound(ApiResponse<object>.NotFound($"Kase with ID '{id}' was not found."));
+
+        _logger.LogInformation("[KASE] Exported kase {Id} as {Format}", id, format);
+
+        return File(result.Content, result.ContentType, fileDownloadName: result.FileName);
     }
 }

--- a/src/KaseLog.Api/KaseLog.Api.csproj
+++ b/src/KaseLog.Api/KaseLog.Api.csproj
@@ -11,7 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.3" />
+    <PackageReference Include="QuestPDF" Version="2024.3.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 

--- a/src/KaseLog.Api/Program.cs
+++ b/src/KaseLog.Api/Program.cs
@@ -3,9 +3,14 @@ using KaseLog.Api.Data;
 using KaseLog.Api.Data.Sqlite;
 using KaseLog.Api.Middleware;
 using KaseLog.Api.Models;
+using KaseLog.Api.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
+using QuestPDF.Infrastructure;
 using System.Reflection;
+
+// QuestPDF community license — free for self-hosted / open-source use
+QuestPDF.Settings.License = LicenseType.Community;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -31,6 +36,9 @@ builder.WebHost.UseUrls($"http://*:{port}");
 var dataDir   = Path.GetDirectoryName(dataPath) ?? "/data";
 var imagesDir = Path.Combine(dataDir, "images");
 builder.Services.AddSingleton(new ImageStorageOptions(imagesDir));
+
+// ── Export service ────────────────────────────────────────────────────────────
+builder.Services.AddScoped<IKaseExportService, KaseExportService>();
 
 // ── Database provider ─────────────────────────────────────────────────────────
 if (dbProvider.Equals("sqlite", StringComparison.OrdinalIgnoreCase))

--- a/src/KaseLog.Api/Services/IKaseExportService.cs
+++ b/src/KaseLog.Api/Services/IKaseExportService.cs
@@ -1,0 +1,22 @@
+namespace KaseLog.Api.Services;
+
+/// <summary>Builds Markdown and PDF exports for a single Kase.</summary>
+public interface IKaseExportService
+{
+    /// <summary>
+    /// Exports the Kase as a single Markdown file.
+    /// Returns the filename slug and the UTF-8 encoded file bytes.
+    /// Returns null if the Kase does not exist.
+    /// </summary>
+    Task<ExportResult?> ExportMarkdownAsync(Guid kaseId);
+
+    /// <summary>
+    /// Exports the Kase as a PDF document.
+    /// Returns the filename slug and the PDF bytes.
+    /// Returns null if the Kase does not exist.
+    /// </summary>
+    Task<ExportResult?> ExportPdfAsync(Guid kaseId);
+}
+
+/// <summary>The produced file ready to stream to the client.</summary>
+public sealed record ExportResult(string FileName, string ContentType, byte[] Content);

--- a/src/KaseLog.Api/Services/KaseExportService.cs
+++ b/src/KaseLog.Api/Services/KaseExportService.cs
@@ -1,0 +1,465 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using KaseLog.Api.Data;
+using KaseLog.Api.Models;
+using Markdig;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace KaseLog.Api.Services;
+
+/// <summary>Builds Markdown and PDF exports for a Kase.</summary>
+public sealed class KaseExportService : IKaseExportService
+{
+    private readonly IKaseRepository _kases;
+    private readonly ILogRepository _logs;
+    private readonly ICollectionRepository _collections;
+    private readonly string _imagesDir;
+
+    // Matches /api/images/UID anywhere in content (40-char uppercase alphanumeric)
+    private static readonly Regex _imageApiPattern =
+        new(@"/api/images/([A-Z0-9]{40})", RegexOptions.Compiled);
+
+    public KaseExportService(
+        IKaseRepository kases,
+        ILogRepository logs,
+        ICollectionRepository collections,
+        ImageStorageOptions imageOptions)
+    {
+        _kases       = kases;
+        _logs        = logs;
+        _collections = collections;
+        _imagesDir   = imageOptions.ImagesDirectory;
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    public async Task<ExportResult?> ExportMarkdownAsync(Guid kaseId)
+    {
+        var (kase, logs, collectionGroups) = await GatherDataAsync(kaseId);
+        if (kase is null) return null;
+
+        var md = BuildMarkdown(kase, logs, collectionGroups);
+        var bytes = Encoding.UTF8.GetBytes(md);
+        var fileName = $"{Slug(kase.Title)}.md";
+        return new ExportResult(fileName, "text/markdown; charset=utf-8", bytes);
+    }
+
+    public async Task<ExportResult?> ExportPdfAsync(Guid kaseId)
+    {
+        var (kase, logs, collectionGroups) = await GatherDataAsync(kaseId);
+        if (kase is null) return null;
+
+        var bytes = BuildPdf(kase, logs, collectionGroups);
+        var fileName = $"{Slug(kase.Title)}.pdf";
+        return new ExportResult(fileName, "application/pdf", bytes);
+    }
+
+    // ── Data gathering ────────────────────────────────────────────────────────
+
+    private async Task<(KaseResponse? Kase, List<LogResponse> Logs, List<CollectionGroup> Groups)>
+        GatherDataAsync(Guid kaseId)
+    {
+        var kase = await _kases.GetByIdAsync(kaseId);
+        if (kase is null) return (null, [], []);
+
+        var logs = (await _logs.GetByKaseIdAsync(kaseId))
+            .OrderByDescending(l => l.UpdatedAt)
+            .ToList();
+
+        // Collect items linked to this kase across all collections.
+        var allCollections = (await _collections.GetAllAsync()).ToList();
+        var groups = new List<CollectionGroup>();
+
+        foreach (var col in allCollections)
+        {
+            var items = (await _collections.GetItemsAsync(
+                col.Id, q: null, kaseId: kaseId,
+                fieldFilters: new Dictionary<string, string>(),
+                sortFieldId: null, sortAsc: false,
+                page: 1, pageSize: 10_000)).ToList();
+
+            if (items.Count == 0) continue;
+
+            var fields = (await _collections.GetFieldsAsync(col.Id))
+                .OrderBy(f => f.SortOrder)
+                .ToList();
+
+            groups.Add(new CollectionGroup(col, fields, items));
+        }
+
+        return (kase, logs, groups);
+    }
+
+    // ── Markdown builder ──────────────────────────────────────────────────────
+
+    private string BuildMarkdown(
+        KaseResponse kase,
+        List<LogResponse> logs,
+        List<CollectionGroup> groups)
+    {
+        var sb = new StringBuilder();
+
+        // Header
+        sb.AppendLine($"# {kase.Title}");
+        sb.AppendLine();
+        if (!string.IsNullOrWhiteSpace(kase.Description))
+        {
+            sb.AppendLine(kase.Description);
+            sb.AppendLine();
+        }
+        sb.AppendLine($"*Created: {kase.CreatedAt:yyyy-MM-dd}*");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+
+        // Logs
+        if (logs.Count > 0)
+        {
+            sb.AppendLine("## Logs");
+            sb.AppendLine();
+
+            foreach (var log in logs)
+            {
+                sb.AppendLine($"### {log.Title}");
+                sb.AppendLine();
+
+                var meta = new List<string>();
+                if (log.Tags.Count > 0)
+                    meta.Add($"**Tags:** {string.Join(", ", log.Tags.Select(t => t.Name))}");
+                meta.Add($"**Versions:** {log.VersionCount}");
+                meta.Add($"**Updated:** {log.UpdatedAt:yyyy-MM-dd}");
+
+                foreach (var m in meta) sb.AppendLine(m);
+                sb.AppendLine();
+
+                // Rewrite image URLs for filesystem portability
+                var content = RewriteImageUrlsForMarkdown(log.Content);
+                sb.AppendLine(content);
+                sb.AppendLine();
+                sb.AppendLine("---");
+                sb.AppendLine();
+            }
+        }
+
+        // Collection items appendix
+        if (groups.Count > 0)
+        {
+            sb.AppendLine("## Collection Items");
+            sb.AppendLine();
+
+            foreach (var group in groups)
+            {
+                sb.AppendLine($"### {group.Collection.Title}");
+                sb.AppendLine();
+
+                foreach (var item in group.Items)
+                {
+                    sb.AppendLine("| Field | Value |");
+                    sb.AppendLine("|-------|-------|");
+
+                    foreach (var field in group.Fields)
+                    {
+                        var raw = GetFieldValue(item.FieldValues, field.Id.ToString());
+                        var display = FormatFieldValueMarkdown(field, raw);
+                        sb.AppendLine($"| {Escape(field.Name)} | {Escape(display)} |");
+                    }
+
+                    sb.AppendLine();
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    // ── PDF builder ───────────────────────────────────────────────────────────
+
+    private byte[] BuildPdf(
+        KaseResponse kase,
+        List<LogResponse> logs,
+        List<CollectionGroup> groups)
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(2, Unit.Centimetre);
+                page.DefaultTextStyle(x => x.FontSize(10).FontFamily("Arial"));
+
+                page.Header().Column(col =>
+                {
+                    col.Item()
+                        .Text(kase.Title)
+                        .FontSize(20).Bold().FontColor(Colors.Grey.Darken3);
+
+                    if (!string.IsNullOrWhiteSpace(kase.Description))
+                    {
+                        col.Item().PaddingTop(4)
+                            .Text(kase.Description)
+                            .FontSize(11).Italic().FontColor(Colors.Grey.Darken1);
+                    }
+
+                    col.Item().PaddingTop(4)
+                        .Text($"Created {kase.CreatedAt:MMMM d, yyyy}  ·  {logs.Count} log(s)")
+                        .FontSize(9).FontColor(Colors.Grey.Medium);
+
+                    col.Item().PaddingTop(8).LineHorizontal(1).LineColor(Colors.Grey.Lighten1);
+                });
+
+                page.Footer().AlignCenter()
+                    .Text(x =>
+                    {
+                        x.Span("Page ").FontSize(8).FontColor(Colors.Grey.Medium);
+                        x.CurrentPageNumber().FontSize(8).FontColor(Colors.Grey.Medium);
+                        x.Span(" of ").FontSize(8).FontColor(Colors.Grey.Medium);
+                        x.TotalPages().FontSize(8).FontColor(Colors.Grey.Medium);
+                    });
+
+                page.Content().Column(col =>
+                {
+                    col.Spacing(16);
+
+                    // ── Logs ────────────────────────────────────────────────
+                    if (logs.Count > 0)
+                    {
+                        col.Item()
+                            .Text("Logs")
+                            .FontSize(14).Bold().FontColor(Colors.Grey.Darken2);
+
+                        foreach (var log in logs)
+                        {
+                            col.Item().Column(logCol =>
+                            {
+                                logCol.Spacing(4);
+
+                                // Title row
+                                logCol.Item().Row(row =>
+                                {
+                                    row.RelativeItem()
+                                        .Text(log.Title)
+                                        .FontSize(12).Bold();
+
+                                    row.AutoItem().AlignRight()
+                                        .Text($"v{log.VersionCount}  ·  {log.UpdatedAt:yyyy-MM-dd}")
+                                        .FontSize(8).FontColor(Colors.Grey.Medium);
+                                });
+
+                                // Tags
+                                if (log.Tags.Count > 0)
+                                {
+                                    logCol.Item()
+                                        .Text($"Tags: {string.Join(", ", log.Tags.Select(t => t.Name))}")
+                                        .FontSize(8).Italic().FontColor(Colors.Grey.Darken1);
+                                }
+
+                                logCol.Item().LineHorizontal(0.5f).LineColor(Colors.Grey.Lighten2);
+
+                                // Content: render markdown as plain text with inline images
+                                RenderMarkdownContent(logCol, log.Content, pipeline);
+                            });
+
+                            col.Item().LineHorizontal(1).LineColor(Colors.Grey.Lighten1);
+                        }
+                    }
+
+                    // ── Collection items appendix ────────────────────────
+                    if (groups.Count > 0)
+                    {
+                        col.Item()
+                            .Text("Collection Items")
+                            .FontSize(14).Bold().FontColor(Colors.Grey.Darken2);
+
+                        foreach (var group in groups)
+                        {
+                            col.Item().Column(grpCol =>
+                            {
+                                grpCol.Spacing(6);
+
+                                grpCol.Item()
+                                    .Text(group.Collection.Title)
+                                    .FontSize(12).Bold();
+
+                                foreach (var item in group.Items)
+                                {
+                                    grpCol.Item().Table(table =>
+                                    {
+                                        table.ColumnsDefinition(c =>
+                                        {
+                                            c.RelativeColumn(1);
+                                            c.RelativeColumn(2);
+                                        });
+
+                                        foreach (var field in group.Fields)
+                                        {
+                                            var raw = GetFieldValue(item.FieldValues, field.Id.ToString());
+                                            var display = FormatFieldValuePdf(field, raw);
+
+                                            table.Cell().Background(Colors.Grey.Lighten3)
+                                                .Padding(4)
+                                                .Text(field.Name).FontSize(9).Bold();
+
+                                            table.Cell().Padding(4)
+                                                .Text(display).FontSize(9);
+                                        }
+                                    });
+
+                                    if (group.Items.Count > 1)
+                                        grpCol.Item().PaddingTop(4).LineHorizontal(0.5f).LineColor(Colors.Grey.Lighten2);
+                                }
+                            });
+                        }
+                    }
+                });
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    // ── Markdown content renderer for PDF ─────────────────────────────────────
+
+    private void RenderMarkdownContent(ColumnDescriptor col, string markdown, MarkdownPipeline pipeline)
+    {
+        // Split markdown into blocks; render images inline, text as plain paragraphs.
+        var lines = markdown.Split('\n');
+        var textBuffer = new StringBuilder();
+
+        void FlushText()
+        {
+            var text = textBuffer.ToString().Trim();
+            if (string.IsNullOrEmpty(text)) { textBuffer.Clear(); return; }
+
+            // Strip markdown to plain readable text via Markdig's plain-text renderer
+            var plain = Markdown.ToPlainText(text, pipeline).Trim();
+            if (!string.IsNullOrEmpty(plain))
+            {
+                col.Item()
+                    .Text(plain)
+                    .FontSize(9).FontColor(Colors.Grey.Darken3)
+                    .LineHeight(1.4f);
+            }
+            textBuffer.Clear();
+        }
+
+        foreach (var line in lines)
+        {
+            // Detect image markdown: ![alt](/api/images/UID)
+            var imgMatch = Regex.Match(line, @"!\[.*?\]\(/api/images/([A-Z0-9]{40})\)");
+            if (imgMatch.Success)
+            {
+                FlushText();
+                var uid = imgMatch.Groups[1].Value;
+                var imgBytes = FindImageBytes(uid);
+                if (imgBytes is not null)
+                {
+                    col.Item().MaxWidth(400).Image(imgBytes);
+                }
+                continue;
+            }
+
+            // Also detect HTML img tags: <img src="/api/images/UID" ...>
+            var htmlImgMatch = Regex.Match(line, @"<img[^>]+src=""/api/images/([A-Z0-9]{40})""");
+            if (htmlImgMatch.Success)
+            {
+                FlushText();
+                var uid = htmlImgMatch.Groups[1].Value;
+                var imgBytes = FindImageBytes(uid);
+                if (imgBytes is not null)
+                {
+                    col.Item().MaxWidth(400).Image(imgBytes);
+                }
+                continue;
+            }
+
+            textBuffer.AppendLine(line);
+        }
+
+        FlushText();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>Rewrites /api/images/UID to /data/images/UID.ext in markdown content.</summary>
+    private string RewriteImageUrlsForMarkdown(string content) =>
+        _imageApiPattern.Replace(content, m =>
+        {
+            var uid = m.Groups[1].Value;
+            var ext = FindImageExtension(uid);
+            return ext is null ? m.Value : $"/data/images/{uid}{ext}";
+        });
+
+    private string? FindImageExtension(string uid)
+    {
+        if (!Directory.Exists(_imagesDir)) return null;
+        var files = Directory.GetFiles(_imagesDir, $"{uid}.*");
+        return files.Length > 0 ? Path.GetExtension(files[0]) : null;
+    }
+
+    private byte[]? FindImageBytes(string uid)
+    {
+        if (!Directory.Exists(_imagesDir)) return null;
+        var files = Directory.GetFiles(_imagesDir, $"{uid}.*");
+        return files.Length > 0 ? File.ReadAllBytes(files[0]) : null;
+    }
+
+    private static string GetFieldValue(JsonElement fieldValues, string fieldId)
+    {
+        if (fieldValues.ValueKind == JsonValueKind.Object &&
+            fieldValues.TryGetProperty(fieldId, out var val))
+        {
+            return val.ValueKind switch
+            {
+                JsonValueKind.String => val.GetString() ?? string.Empty,
+                JsonValueKind.Number => val.GetRawText(),
+                JsonValueKind.True   => "Yes",
+                JsonValueKind.False  => "No",
+                JsonValueKind.Null   => string.Empty,
+                _                   => val.GetRawText(),
+            };
+        }
+        return string.Empty;
+    }
+
+    private static string FormatFieldValueMarkdown(CollectionFieldResponse field, string raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return "—";
+        return field.Type switch
+        {
+            "rating"  => new string('★', int.TryParse(raw, out var r) ? r : 0),
+            "boolean" => raw,
+            "url"     => $"[{raw}]({raw})",
+            "image"   => $"/data/images/{raw}",
+            _         => raw,
+        };
+    }
+
+    private static string FormatFieldValuePdf(CollectionFieldResponse field, string raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return "—";
+        return field.Type switch
+        {
+            "rating"  => new string('★', int.TryParse(raw, out var r) ? r : 0),
+            "image"   => "[image]",
+            _         => raw,
+        };
+    }
+
+    private static string Escape(string s) =>
+        s.Replace("|", "\\|").Replace("\n", " ");
+
+    private static string Slug(string title) =>
+        Regex.Replace(title.ToLowerInvariant(), @"[^a-z0-9]+", "-").Trim('-');
+
+    // ── Inner types ───────────────────────────────────────────────────────────
+
+    private sealed record CollectionGroup(
+        CollectionResponse Collection,
+        List<CollectionFieldResponse> Fields,
+        List<CollectionItemResponse> Items);
+}

--- a/src/kaselog-ui/src/api/client.ts
+++ b/src/kaselog-ui/src/api/client.ts
@@ -76,6 +76,24 @@ export const kases = {
 
   unpin: (id: string): Promise<KaseResponse> =>
     request<KaseResponse>(`/api/kases/${id}/unpin`, { method: 'POST' }),
+
+  /** Triggers a file download for the given export format. */
+  export: async (id: string, format: 'markdown' | 'pdf'): Promise<void> => {
+    const res = await fetch(`/api/kases/${id}/export?format=${format}`, {
+      cache: 'no-store',
+    })
+    if (!res.ok) throw new Error(`Export failed: ${res.status}`)
+    const blob = await res.blob()
+    const disposition = res.headers.get('Content-Disposition') ?? ''
+    const nameMatch = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(disposition)
+    const fileName = nameMatch ? nameMatch[1].replace(/['"]/g, '') : `kase.${format === 'pdf' ? 'pdf' : 'md'}`
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = fileName
+    a.click()
+    URL.revokeObjectURL(url)
+  },
 }
 
 // ── Logs ──────────────────────────────────────────────────────────────────────

--- a/src/kaselog-ui/src/pages/KaseViewPage.tsx
+++ b/src/kaselog-ui/src/pages/KaseViewPage.tsx
@@ -64,6 +64,7 @@ function KaseSettingsPanel({ kase, entryCount, onClose, onUpdated, onDeleted, on
   const [pinning, setPinning] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [exporting, setExporting] = useState<'markdown' | 'pdf' | null>(null)
 
   useEffect(() => {
     setLocalTitle(kase.title)
@@ -104,6 +105,16 @@ function KaseSettingsPanel({ kase, entryCount, onClose, onUpdated, onDeleted, on
       onPinToggled(updated)
     } catch { /* ignore */ } finally {
       setPinning(false)
+    }
+  }
+
+  async function handleExport(format: 'markdown' | 'pdf') {
+    if (exporting) return
+    setExporting(format)
+    try {
+      await kasesApi.export(kase.id, format)
+    } catch { /* ignore */ } finally {
+      setExporting(null)
     }
   }
 
@@ -248,6 +259,39 @@ function KaseSettingsPanel({ kase, entryCount, onClose, onUpdated, onDeleted, on
               <span>Entries</span>
               <span style={{ color: 'var(--text-primary)' }}>{entryCount}</span>
             </div>
+          </div>
+
+          <div style={{ height: 1, background: 'var(--border)' }} />
+
+          {/* Export */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div style={{ fontSize: 'var(--text-xs)', fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 2 }}>
+              Export
+            </div>
+            <button
+              onClick={() => handleExport('markdown')}
+              disabled={exporting !== null}
+              style={{
+                fontSize: 'var(--text-sm)', color: 'var(--text-secondary)', cursor: exporting ? 'not-allowed' : 'pointer',
+                background: 'var(--bg-secondary)', border: '1px solid var(--border-mid)',
+                borderRadius: 7, padding: '6px 10px', fontFamily: 'inherit', textAlign: 'left',
+                opacity: exporting === 'markdown' ? 0.6 : 1,
+              }}
+            >
+              {exporting === 'markdown' ? 'Exporting…' : 'Export as Markdown'}
+            </button>
+            <button
+              onClick={() => handleExport('pdf')}
+              disabled={exporting !== null}
+              style={{
+                fontSize: 'var(--text-sm)', color: 'var(--text-secondary)', cursor: exporting ? 'not-allowed' : 'pointer',
+                background: 'var(--bg-secondary)', border: '1px solid var(--border-mid)',
+                borderRadius: 7, padding: '6px 10px', fontFamily: 'inherit', textAlign: 'left',
+                opacity: exporting === 'pdf' ? 0.6 : 1,
+              }}
+            >
+              {exporting === 'pdf' ? 'Exporting…' : 'Export as PDF'}
+            </button>
           </div>
 
           <div style={{ height: 1, background: 'var(--border)' }} />

--- a/tests/KaseLog.Api.Tests/Controllers/KaseExportControllerTests.cs
+++ b/tests/KaseLog.Api.Tests/Controllers/KaseExportControllerTests.cs
@@ -1,0 +1,278 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Dapper;
+using KaseLog.Api.Data;
+using KaseLog.Api.Data.Sqlite;
+using KaseLog.Api.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace KaseLog.Api.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for GET /api/kases/{id}/export.
+/// </summary>
+public sealed class KaseExportControllerTests : IAsyncLifetime
+{
+    private readonly string _dbName;
+    private string _testConnString = null!;
+    private SqliteConnection _keepAlive = null!;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public KaseExportControllerTests()
+    {
+        _dbName = $"ExportTest_{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        _testConnString = $"Data Source={_dbName};Mode=Memory;Cache=Shared";
+        _keepAlive      = new SqliteConnection(_testConnString);
+        await _keepAlive.OpenAsync();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), _dbName);
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH",
+            Path.Combine(tempDir, "kaselog.db"));
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IDbConnectionFactory));
+                    if (descriptor is not null) services.Remove(descriptor);
+
+                    services.AddSingleton<IDbConnectionFactory>(
+                        new SqliteConnectionFactory(_testConnString));
+
+                    var seedDescriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(ISeedInitializer));
+                    if (seedDescriptor is not null) services.Remove(seedDescriptor);
+
+                    services.AddSingleton<ISeedInitializer, NoopSeedInitializer>();
+                });
+            });
+
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH", null);
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _keepAlive.DisposeAsync();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<string> CreateKaseAsync(string title, string? description = null)
+    {
+        var res = await _client.PostAsJsonAsync("/api/kases", new { title, description });
+        res.EnsureSuccessStatusCode();
+        var root = JsonDocument.Parse(await res.Content.ReadAsStringAsync()).RootElement;
+        return root.GetProperty("data").GetProperty("id").GetString()!;
+    }
+
+    private async Task CreateLogAsync(string kaseId, string title, string content)
+    {
+        var res = await _client.PostAsJsonAsync($"/api/kases/{kaseId}/logs",
+            new { title, description = (string?)null, autosaveEnabled = true });
+        res.EnsureSuccessStatusCode();
+        var root = JsonDocument.Parse(await res.Content.ReadAsStringAsync()).RootElement;
+        var logId = root.GetProperty("data").GetProperty("id").GetString()!;
+
+        // Add a version with content
+        await _client.PostAsJsonAsync($"/api/logs/{logId}/versions",
+            new { content, label = (string?)null, isAutosave = false });
+    }
+
+    private async Task<string> CreateCollectionAsync(string title)
+    {
+        var res = await _client.PostAsJsonAsync("/api/collections",
+            new { title, color = "teal" });
+        res.EnsureSuccessStatusCode();
+        var root = JsonDocument.Parse(await res.Content.ReadAsStringAsync()).RootElement;
+        return root.GetProperty("data").GetProperty("id").GetString()!;
+    }
+
+    private async Task<string> AddFieldAsync(string collectionId, string name, string type)
+    {
+        var res = await _client.PostAsJsonAsync($"/api/collections/{collectionId}/fields",
+            new { name, type, required = false, showInList = true, options = (string[]?)null });
+        res.EnsureSuccessStatusCode();
+        var root = JsonDocument.Parse(await res.Content.ReadAsStringAsync()).RootElement;
+        return root.GetProperty("data").GetProperty("id").GetString()!;
+    }
+
+    private async Task CreateItemLinkedToKaseAsync(string collectionId, string kaseId, string fieldId, string fieldValue)
+    {
+        var fieldValues = new Dictionary<string, object> { [fieldId] = fieldValue };
+        var res = await _client.PostAsJsonAsync($"/api/collections/{collectionId}/items",
+            new { kaseId, fieldValues });
+        res.EnsureSuccessStatusCode();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Export_Markdown_UnknownKase_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/kases/{Guid.NewGuid()}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Export_Pdf_UnknownKase_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/kases/{Guid.NewGuid()}/export?format=pdf");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Export_InvalidFormat_Returns400()
+    {
+        var kaseId = await CreateKaseAsync("Test Kase");
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export?format=xlsx");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_ValidKase_ReturnsMarkdownFile()
+    {
+        var kaseId = await CreateKaseAsync("My Export Kase", "A description for testing");
+        await CreateLogAsync(kaseId, "First Log", "## Hello\n\nThis is the log content.");
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/markdown", response.Content.Headers.ContentType?.MediaType);
+
+        var disposition = response.Content.Headers.ContentDisposition;
+        Assert.NotNull(disposition);
+        Assert.EndsWith(".md", disposition!.FileName?.Trim('"'));
+
+        var text = await response.Content.ReadAsStringAsync();
+        Assert.Contains("My Export Kase", text);
+        Assert.Contains("First Log", text);
+        Assert.Contains("Hello", text);
+        Assert.Contains("log content", text);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_IncludesAllLogs()
+    {
+        var kaseId = await CreateKaseAsync("Multi Log Kase");
+        await CreateLogAsync(kaseId, "Alpha Log", "Content Alpha");
+        await CreateLogAsync(kaseId, "Beta Log", "Content Beta");
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var text = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Alpha Log", text);
+        Assert.Contains("Beta Log", text);
+        Assert.Contains("Content Alpha", text);
+        Assert.Contains("Content Beta", text);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_DefaultsToMarkdownFormat()
+    {
+        var kaseId = await CreateKaseAsync("Default Format Kase");
+        // No format query param — should default to markdown
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var text = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Default Format Kase", text);
+    }
+
+    [Fact]
+    public async Task Export_Pdf_ValidKase_ReturnsPdfBinary()
+    {
+        var kaseId = await CreateKaseAsync("PDF Kase", "PDF export test");
+        await CreateLogAsync(kaseId, "Log One", "Some content here.");
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export?format=pdf");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
+
+        var disposition = response.Content.Headers.ContentDisposition;
+        Assert.NotNull(disposition);
+        Assert.EndsWith(".pdf", disposition!.FileName?.Trim('"'));
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        Assert.True(bytes.Length > 0, "PDF should be non-empty");
+        // PDF magic bytes: %PDF
+        Assert.Equal((byte)'%', bytes[0]);
+        Assert.Equal((byte)'P', bytes[1]);
+        Assert.Equal((byte)'D', bytes[2]);
+        Assert.Equal((byte)'F', bytes[3]);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_IncludesCollectionItemsAppendix()
+    {
+        var kaseId       = await CreateKaseAsync("Kase With Items");
+        var colId        = await CreateCollectionAsync("Gear");
+        var fieldId      = await AddFieldAsync(colId, "Name", "text");
+        await CreateItemLinkedToKaseAsync(colId, kaseId, fieldId, "Canon R5");
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var text = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Collection Items", text);
+        Assert.Contains("Gear", text);
+        Assert.Contains("Canon R5", text);
+    }
+
+    [Fact]
+    public async Task Export_Pdf_IncludesCollectionItemsAppendix()
+    {
+        var kaseId  = await CreateKaseAsync("PDF With Items");
+        var colId   = await CreateCollectionAsync("Books");
+        var fieldId = await AddFieldAsync(colId, "Title", "text");
+        await CreateItemLinkedToKaseAsync(colId, kaseId, fieldId, "The Phoenix Project");
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export?format=pdf");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        Assert.True(bytes.Length > 0);
+        // Valid PDF header
+        Assert.Equal((byte)'%', bytes[0]);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_ContentDispositionHeaderPresent()
+    {
+        var kaseId = await CreateKaseAsync("Disposition Test");
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var disposition = response.Content.Headers.ContentDisposition;
+        Assert.NotNull(disposition);
+        Assert.Equal("attachment", disposition!.DispositionType);
+    }
+
+    [Fact]
+    public async Task Export_Pdf_ContentDispositionHeaderPresent()
+    {
+        var kaseId = await CreateKaseAsync("PDF Disposition Test");
+
+        var response = await _client.GetAsync($"/api/kases/{kaseId}/export?format=pdf");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var disposition = response.Content.Headers.ContentDisposition;
+        Assert.NotNull(disposition);
+        Assert.Equal("attachment", disposition!.DispositionType);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/kases/{id}/export?format=markdown` and `?format=pdf` endpoints that stream a complete portable Kase document
- **Markdown**: single `.md` file with all Logs (reverse-chrono) — image URLs rewritten from `/api/images/{uid}` to `/data/images/{uid}.{ext}` for filesystem portability; Collection items appendix as markdown tables
- **PDF**: QuestPDF-generated document with cover header, per-log sections (title, tags, version count, body), Collection items as structured tables, embedded images (read from disk), and page numbers; Markdig strips markdown syntax to readable plain text for PDF body
- **Frontend**: "Export as Markdown" and "Export as PDF" buttons added to the Kase settings panel; download begins immediately on click with no intermediate screen
- **QuestPDF Community** license declared at startup (free for self-hosted / OSS use); **Markdig** added for markdown-to-plaintext conversion in PDF rendering

## Test plan

- [ ] 9 xUnit integration tests added in `KaseExportControllerTests`:
  - `Export_Markdown_UnknownKase_Returns404`
  - `Export_Pdf_UnknownKase_Returns404`
  - `Export_InvalidFormat_Returns400`
  - `Export_Markdown_ValidKase_ReturnsMarkdownFile` — checks content type, filename, and presence of log content
  - `Export_Markdown_IncludesAllLogs` — verifies multi-log export
  - `Export_Markdown_DefaultsToMarkdownFormat` — no format param defaults to markdown
  - `Export_Pdf_ValidKase_ReturnsPdfBinary` — checks `application/pdf`, `%PDF` magic bytes
  - `Export_Markdown_IncludesCollectionItemsAppendix` — linked collection items appear in export
  - `Export_Pdf_IncludesCollectionItemsAppendix` — PDF with items is non-empty and valid
  - `Export_Markdown_ContentDispositionHeaderPresent` / `Export_Pdf_ContentDispositionHeaderPresent`
- [ ] Run `dotnet test` in `tests/KaseLog.Api.Tests`
- [ ] Open a Kase with logs in the UI → open Kase settings → click Export as Markdown → file downloads
- [ ] Click Export as PDF → PDF downloads and opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)