### PR TITLE
feat: export Log as Markdown or PDF

### DIFF
--- a/src/KaseLog.Api/Controllers/LogsController.cs
+++ b/src/KaseLog.Api/Controllers/LogsController.cs
@@ -1,6 +1,7 @@
 using KaseLog.Api.Data;
 using KaseLog.Api.Models;
 using KaseLog.Api.Models.Requests;
+using KaseLog.Api.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace KaseLog.Api.Controllers;
@@ -12,12 +13,14 @@ namespace KaseLog.Api.Controllers;
 public sealed class LogsController : ControllerBase
 {
     private readonly ILogRepository _logs;
+    private readonly ILogExportService _export;
     private readonly ILogger<LogsController> _logger;
 
     /// <summary>Initialises a new instance of <see cref="LogsController"/>.</summary>
-    public LogsController(ILogRepository logs, ILogger<LogsController> logger)
+    public LogsController(ILogRepository logs, ILogExportService export, ILogger<LogsController> logger)
     {
         _logs   = logs;
+        _export = export;
         _logger = logger;
     }
 
@@ -178,5 +181,39 @@ public sealed class LogsController : ControllerBase
                 $"Version with ID '{versionId}' was not found for Log '{logId}'."));
         _logger.LogInformation("[VERSION] Restored version {SourceVersionId} for log {LogId} — new version {NewVersionId}", versionId, logId, version.Id);
         return Ok(ApiResponse<LogVersionResponse>.Success(version));
+    }
+
+    // ── Export ────────────────────────────────────────────────────────────────
+
+    /// <summary>Exports a Log as a Markdown or PDF file download.</summary>
+    /// <param name="id">The GUID of the Log to export.</param>
+    /// <param name="format">Export format: <c>markdown</c> or <c>pdf</c>.</param>
+    /// <returns>The file as a download, or 404 if the Log is not found.</returns>
+    [HttpGet("{id:guid}/export")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Export(Guid id, [FromQuery] string format = "markdown")
+    {
+        var fmt = format.ToLowerInvariant();
+
+        if (fmt != "markdown" && fmt != "pdf")
+        {
+            return BadRequest(ApiResponse<object>.Failure(
+                "https://tools.ietf.org/html/rfc7807",
+                "Bad Request", 400,
+                "Invalid format. Supported values: markdown, pdf."));
+        }
+
+        var result = fmt == "pdf"
+            ? await _export.ExportPdfAsync(id)
+            : await _export.ExportMarkdownAsync(id);
+
+        if (result is null)
+            return NotFound(ApiResponse<object>.NotFound($"Log with ID '{id}' was not found."));
+
+        _logger.LogInformation("[LOG] Exported log {Id} as {Format}", id, format);
+
+        return File(result.Content, result.ContentType, fileDownloadName: result.FileName);
     }
 }

--- a/src/KaseLog.Api/Program.cs
+++ b/src/KaseLog.Api/Program.cs
@@ -39,6 +39,7 @@ builder.Services.AddSingleton(new ImageStorageOptions(imagesDir));
 
 // ── Export service ────────────────────────────────────────────────────────────
 builder.Services.AddScoped<IKaseExportService, KaseExportService>();
+builder.Services.AddScoped<ILogExportService, LogExportService>();
 
 // ── Database provider ─────────────────────────────────────────────────────────
 if (dbProvider.Equals("sqlite", StringComparison.OrdinalIgnoreCase))

--- a/src/KaseLog.Api/Services/ILogExportService.cs
+++ b/src/KaseLog.Api/Services/ILogExportService.cs
@@ -1,0 +1,19 @@
+namespace KaseLog.Api.Services;
+
+/// <summary>Builds Markdown and PDF exports for a single Log.</summary>
+public interface ILogExportService
+{
+    /// <summary>
+    /// Exports the Log as a single Markdown file.
+    /// Returns the filename slug and the UTF-8 encoded file bytes.
+    /// Returns null if the Log does not exist.
+    /// </summary>
+    Task<ExportResult?> ExportMarkdownAsync(Guid logId);
+
+    /// <summary>
+    /// Exports the Log as a PDF document.
+    /// Returns the filename slug and the PDF bytes.
+    /// Returns null if the Log does not exist.
+    /// </summary>
+    Task<ExportResult?> ExportPdfAsync(Guid logId);
+}

--- a/src/KaseLog.Api/Services/LogExportService.cs
+++ b/src/KaseLog.Api/Services/LogExportService.cs
@@ -1,0 +1,238 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using KaseLog.Api.Data;
+using KaseLog.Api.Models;
+using Markdig;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace KaseLog.Api.Services;
+
+/// <summary>Builds Markdown and PDF exports for a single Log.</summary>
+public sealed class LogExportService : ILogExportService
+{
+    private readonly ILogRepository _logs;
+    private readonly IKaseRepository _kases;
+    private readonly string _imagesDir;
+
+    // Matches /api/images/UID anywhere in content (40-char uppercase alphanumeric)
+    private static readonly Regex _imageApiPattern =
+        new(@"/api/images/([A-Z0-9]{40})", RegexOptions.Compiled);
+
+    public LogExportService(
+        ILogRepository logs,
+        IKaseRepository kases,
+        ImageStorageOptions imageOptions)
+    {
+        _logs      = logs;
+        _kases     = kases;
+        _imagesDir = imageOptions.ImagesDirectory;
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    public async Task<ExportResult?> ExportMarkdownAsync(Guid logId)
+    {
+        var (log, kase) = await GatherDataAsync(logId);
+        if (log is null) return null;
+
+        var md = BuildMarkdown(log, kase);
+        var bytes = Encoding.UTF8.GetBytes(md);
+        var fileName = $"log-{Slug(log.Title)}.md";
+        return new ExportResult(fileName, "text/markdown; charset=utf-8", bytes);
+    }
+
+    public async Task<ExportResult?> ExportPdfAsync(Guid logId)
+    {
+        var (log, kase) = await GatherDataAsync(logId);
+        if (log is null) return null;
+
+        var bytes = BuildPdf(log, kase);
+        var fileName = $"log-{Slug(log.Title)}.pdf";
+        return new ExportResult(fileName, "application/pdf", bytes);
+    }
+
+    // ── Data gathering ────────────────────────────────────────────────────────
+
+    private async Task<(LogResponse? Log, KaseResponse? Kase)> GatherDataAsync(Guid logId)
+    {
+        var log = await _logs.GetByIdAsync(logId);
+        if (log is null) return (null, null);
+
+        var kase = await _kases.GetByIdAsync(log.KaseId);
+        return (log, kase);
+    }
+
+    // ── Markdown builder ──────────────────────────────────────────────────────
+
+    private string BuildMarkdown(LogResponse log, KaseResponse? kase)
+    {
+        var sb = new StringBuilder();
+
+        // Title
+        sb.AppendLine($"# {log.Title}");
+        sb.AppendLine();
+
+        // Metadata
+        if (kase is not null)
+            sb.AppendLine($"**Kase:** {kase.Title}");
+        if (log.Tags.Count > 0)
+            sb.AppendLine($"**Tags:** {string.Join(", ", log.Tags.Select(t => t.Name))}");
+        sb.AppendLine($"**Versions:** {log.VersionCount}");
+        sb.AppendLine($"**Created:** {log.CreatedAt:yyyy-MM-dd}");
+        sb.AppendLine($"**Last edited:** {log.UpdatedAt:yyyy-MM-dd}");
+        sb.AppendLine();
+
+        sb.AppendLine("---");
+        sb.AppendLine();
+
+        // Content — rewrite image URLs for filesystem portability
+        var content = RewriteImageUrlsForMarkdown(log.Content);
+        sb.AppendLine(content);
+
+        return sb.ToString();
+    }
+
+    // ── PDF builder ───────────────────────────────────────────────────────────
+
+    private byte[] BuildPdf(LogResponse log, KaseResponse? kase)
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(2, Unit.Centimetre);
+                page.DefaultTextStyle(x => x.FontSize(10).FontFamily("Arial"));
+
+                page.Header().Column(col =>
+                {
+                    col.Item()
+                        .Text(log.Title)
+                        .FontSize(20).Bold().FontColor(Colors.Grey.Darken3);
+
+                    // Kase name and metadata line
+                    var metaParts = new List<string>();
+                    if (kase is not null) metaParts.Add(kase.Title);
+                    if (log.Tags.Count > 0)
+                        metaParts.Add($"Tags: {string.Join(", ", log.Tags.Select(t => t.Name))}");
+                    metaParts.Add($"v{log.VersionCount}");
+                    metaParts.Add($"Created {log.CreatedAt:yyyy-MM-dd}");
+                    metaParts.Add($"Edited {log.UpdatedAt:yyyy-MM-dd}");
+
+                    col.Item().PaddingTop(4)
+                        .Text(string.Join("  ·  ", metaParts))
+                        .FontSize(9).FontColor(Colors.Grey.Medium);
+
+                    col.Item().PaddingTop(8).LineHorizontal(1).LineColor(Colors.Grey.Lighten1);
+                });
+
+                page.Footer().AlignCenter()
+                    .Text(x =>
+                    {
+                        x.Span("Page ").FontSize(8).FontColor(Colors.Grey.Medium);
+                        x.CurrentPageNumber().FontSize(8).FontColor(Colors.Grey.Medium);
+                        x.Span(" of ").FontSize(8).FontColor(Colors.Grey.Medium);
+                        x.TotalPages().FontSize(8).FontColor(Colors.Grey.Medium);
+                    });
+
+                page.Content().Column(col =>
+                {
+                    col.Spacing(8);
+                    RenderMarkdownContent(col, log.Content, pipeline);
+                });
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    // ── Markdown content renderer for PDF ─────────────────────────────────────
+
+    private void RenderMarkdownContent(ColumnDescriptor col, string markdown, MarkdownPipeline pipeline)
+    {
+        var lines = markdown.Split('\n');
+        var textBuffer = new StringBuilder();
+
+        void FlushText()
+        {
+            var text = textBuffer.ToString().Trim();
+            if (string.IsNullOrEmpty(text)) { textBuffer.Clear(); return; }
+
+            var plain = Markdown.ToPlainText(text, pipeline).Trim();
+            if (!string.IsNullOrEmpty(plain))
+            {
+                col.Item()
+                    .Text(plain)
+                    .FontSize(9).FontColor(Colors.Grey.Darken3)
+                    .LineHeight(1.4f);
+            }
+            textBuffer.Clear();
+        }
+
+        foreach (var line in lines)
+        {
+            // Detect image markdown: ![alt](/api/images/UID)
+            var imgMatch = Regex.Match(line, @"!\[.*?\]\(/api/images/([A-Z0-9]{40})\)");
+            if (imgMatch.Success)
+            {
+                FlushText();
+                var uid = imgMatch.Groups[1].Value;
+                var imgBytes = FindImageBytes(uid);
+                if (imgBytes is not null)
+                {
+                    col.Item().MaxWidth(400).Image(imgBytes);
+                }
+                continue;
+            }
+
+            // Detect HTML img tags: <img src="/api/images/UID" ...>
+            var htmlImgMatch = Regex.Match(line, @"<img[^>]+src=""/api/images/([A-Z0-9]{40})""");
+            if (htmlImgMatch.Success)
+            {
+                FlushText();
+                var uid = htmlImgMatch.Groups[1].Value;
+                var imgBytes = FindImageBytes(uid);
+                if (imgBytes is not null)
+                {
+                    col.Item().MaxWidth(400).Image(imgBytes);
+                }
+                continue;
+            }
+
+            textBuffer.AppendLine(line);
+        }
+
+        FlushText();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private string RewriteImageUrlsForMarkdown(string content) =>
+        _imageApiPattern.Replace(content, m =>
+        {
+            var uid = m.Groups[1].Value;
+            var ext = FindImageExtension(uid);
+            return ext is null ? m.Value : $"/data/images/{uid}{ext}";
+        });
+
+    private string? FindImageExtension(string uid)
+    {
+        if (!Directory.Exists(_imagesDir)) return null;
+        var files = Directory.GetFiles(_imagesDir, $"{uid}.*");
+        return files.Length > 0 ? Path.GetExtension(files[0]) : null;
+    }
+
+    private byte[]? FindImageBytes(string uid)
+    {
+        if (!Directory.Exists(_imagesDir)) return null;
+        var files = Directory.GetFiles(_imagesDir, $"{uid}.*");
+        return files.Length > 0 ? File.ReadAllBytes(files[0]) : null;
+    }
+
+    private static string Slug(string title) =>
+        Regex.Replace(title.ToLowerInvariant(), @"[^a-z0-9]+", "-").Trim('-');
+}

--- a/src/kaselog-ui/src/api/client.ts
+++ b/src/kaselog-ui/src/api/client.ts
@@ -125,6 +125,24 @@ export const logs = {
       method: 'PATCH',
       body: JSON.stringify(body),
     }),
+
+  /** Triggers a file download for the given export format. */
+  export: async (id: string, format: 'markdown' | 'pdf'): Promise<void> => {
+    const res = await fetch(`/api/logs/${id}/export?format=${format}`, {
+      cache: 'no-store',
+    })
+    if (!res.ok) throw new Error(`Export failed: ${res.status}`)
+    const blob = await res.blob()
+    const disposition = res.headers.get('Content-Disposition') ?? ''
+    const nameMatch = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(disposition)
+    const fileName = nameMatch ? nameMatch[1].replace(/['"]/g, '') : `log.${format === 'pdf' ? 'pdf' : 'md'}`
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = fileName
+    a.click()
+    URL.revokeObjectURL(url)
+  },
 }
 
 // ── Log versions ──────────────────────────────────────────────────────────────

--- a/src/kaselog-ui/src/pages/LogViewPage.tsx
+++ b/src/kaselog-ui/src/pages/LogViewPage.tsx
@@ -932,6 +932,51 @@ export default function LogViewPage() {
                     ))}
                   </div>
                 </div>
+
+                <SpDivider />
+
+                {/* Export */}
+                <div>
+                  <SpLabel>Export</SpLabel>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                    <button
+                      data-testid="export-markdown-btn"
+                      onClick={() => void logsApi.export(log.id, 'markdown')}
+                      style={{
+                        width: '100%',
+                        fontSize: 'var(--text-sm)',
+                        color: 'var(--text-secondary)',
+                        background: 'var(--bg)',
+                        border: '1px solid var(--border-mid)',
+                        borderRadius: 5,
+                        padding: '0.4rem 0.6rem',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        fontFamily: 'var(--font)',
+                      }}
+                    >
+                      Export as Markdown
+                    </button>
+                    <button
+                      data-testid="export-pdf-btn"
+                      onClick={() => void logsApi.export(log.id, 'pdf')}
+                      style={{
+                        width: '100%',
+                        fontSize: 'var(--text-sm)',
+                        color: 'var(--text-secondary)',
+                        background: 'var(--bg)',
+                        border: '1px solid var(--border-mid)',
+                        borderRadius: 5,
+                        padding: '0.4rem 0.6rem',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        fontFamily: 'var(--font)',
+                      }}
+                    >
+                      Export as PDF
+                    </button>
+                  </div>
+                </div>
               </div>
 
               {/* Delete */}

--- a/tests/KaseLog.Api.Tests/Controllers/LogExportControllerTests.cs
+++ b/tests/KaseLog.Api.Tests/Controllers/LogExportControllerTests.cs
@@ -1,0 +1,271 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using KaseLog.Api.Data;
+using KaseLog.Api.Data.Sqlite;
+using KaseLog.Api.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace KaseLog.Api.Tests.Controllers;
+
+/// <summary>
+/// Integration tests for GET /api/logs/{id}/export.
+/// </summary>
+public sealed class LogExportControllerTests : IAsyncLifetime
+{
+    private readonly string _dbName;
+    private string _testConnString = null!;
+    private SqliteConnection _keepAlive = null!;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public LogExportControllerTests()
+    {
+        _dbName = $"LogExportTest_{Guid.NewGuid():N}";
+    }
+
+    public async Task InitializeAsync()
+    {
+        _testConnString = $"Data Source={_dbName};Mode=Memory;Cache=Shared";
+        _keepAlive      = new SqliteConnection(_testConnString);
+        await _keepAlive.OpenAsync();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), _dbName);
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH",
+            Path.Combine(tempDir, "kaselog.db"));
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IDbConnectionFactory));
+                    if (descriptor is not null) services.Remove(descriptor);
+
+                    services.AddSingleton<IDbConnectionFactory>(
+                        new SqliteConnectionFactory(_testConnString));
+
+                    var seedDescriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(ISeedInitializer));
+                    if (seedDescriptor is not null) services.Remove(seedDescriptor);
+
+                    services.AddSingleton<ISeedInitializer, NoopSeedInitializer>();
+                });
+            });
+
+        _client = _factory.CreateClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("KASELOG_DATA_PATH", null);
+        _client.Dispose();
+        await _factory.DisposeAsync();
+        await _keepAlive.DisposeAsync();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<string> CreateKaseAsync(string title)
+    {
+        var res = await _client.PostAsJsonAsync("/api/kases", new { title, description = (string?)null });
+        res.EnsureSuccessStatusCode();
+        var root = JsonDocument.Parse(await res.Content.ReadAsStringAsync()).RootElement;
+        return root.GetProperty("data").GetProperty("id").GetString()!;
+    }
+
+    private async Task<string> CreateLogAsync(string kaseId, string title, string content)
+    {
+        var res = await _client.PostAsJsonAsync($"/api/kases/{kaseId}/logs",
+            new { title, description = (string?)null, autosaveEnabled = true });
+        res.EnsureSuccessStatusCode();
+        var root = JsonDocument.Parse(await res.Content.ReadAsStringAsync()).RootElement;
+        var logId = root.GetProperty("data").GetProperty("id").GetString()!;
+
+        await _client.PostAsJsonAsync($"/api/logs/{logId}/versions",
+            new { content, label = (string?)null, isAutosave = false });
+
+        return logId;
+    }
+
+    private async Task AddTagAsync(string logId, string tagName)
+    {
+        var res = await _client.PostAsJsonAsync($"/api/logs/{logId}/tags", new { name = tagName });
+        res.EnsureSuccessStatusCode();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Export_Markdown_UnknownLog_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/logs/{Guid.NewGuid()}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Export_Pdf_UnknownLog_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/logs/{Guid.NewGuid()}/export?format=pdf");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Export_InvalidFormat_Returns400()
+    {
+        var kaseId = await CreateKaseAsync("Test Kase");
+        var logId  = await CreateLogAsync(kaseId, "Test Log", "content");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=xlsx");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_ValidLog_ReturnsMarkdownFile()
+    {
+        var kaseId = await CreateKaseAsync("My Kase");
+        var logId  = await CreateLogAsync(kaseId, "My Export Log", "## Section\n\nSome log content.");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/markdown", response.Content.Headers.ContentType?.MediaType);
+
+        var text = await response.Content.ReadAsStringAsync();
+        Assert.Contains("My Export Log", text);
+        Assert.Contains("Section", text);
+        Assert.Contains("log content", text);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_IncludesKaseName()
+    {
+        var kaseId = await CreateKaseAsync("The Kase Name");
+        var logId  = await CreateLogAsync(kaseId, "My Log", "content");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var text = await response.Content.ReadAsStringAsync();
+        Assert.Contains("The Kase Name", text);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_IncludesTags()
+    {
+        var kaseId = await CreateKaseAsync("Kase");
+        var logId  = await CreateLogAsync(kaseId, "Tagged Log", "content");
+        await AddTagAsync(logId, "networking");
+        await AddTagAsync(logId, "proxmox");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var text = await response.Content.ReadAsStringAsync();
+        Assert.Contains("networking", text);
+        Assert.Contains("proxmox", text);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_IncludesVersionCountAndTimestamps()
+    {
+        var kaseId = await CreateKaseAsync("Kase");
+        var logId  = await CreateLogAsync(kaseId, "Versioned Log", "v1 content");
+
+        // Add a second version so versionCount > 1
+        await _client.PostAsJsonAsync($"/api/logs/{logId}/versions",
+            new { content = "v2 content", label = (string?)null, isAutosave = false });
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var text = await response.Content.ReadAsStringAsync();
+        // Versions count should be present
+        Assert.Contains("Versions:", text);
+        // Created and Last edited dates should be present
+        Assert.Contains("Created:", text);
+        Assert.Contains("Last edited:", text);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_DefaultsToMarkdownFormat()
+    {
+        var kaseId = await CreateKaseAsync("Kase");
+        var logId  = await CreateLogAsync(kaseId, "Default Format Log", "content");
+
+        // No format param — should default to markdown
+        var response = await _client.GetAsync($"/api/logs/{logId}/export");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/markdown", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task Export_Markdown_FilenameSlugged()
+    {
+        var kaseId = await CreateKaseAsync("Kase");
+        var logId  = await CreateLogAsync(kaseId, "My Cool Log", "content");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var disposition = response.Content.Headers.ContentDisposition;
+        Assert.NotNull(disposition);
+        Assert.EndsWith(".md", disposition!.FileName?.Trim('"'));
+        Assert.Contains("log-", disposition!.FileName?.Trim('"'));
+    }
+
+    [Fact]
+    public async Task Export_Markdown_ContentDispositionHeaderPresent()
+    {
+        var kaseId = await CreateKaseAsync("Kase");
+        var logId  = await CreateLogAsync(kaseId, "Disposition Test Log", "content");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=markdown");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var disposition = response.Content.Headers.ContentDisposition;
+        Assert.NotNull(disposition);
+        Assert.Equal("attachment", disposition!.DispositionType);
+    }
+
+    [Fact]
+    public async Task Export_Pdf_ValidLog_ReturnsPdfBinary()
+    {
+        var kaseId = await CreateKaseAsync("PDF Kase");
+        var logId  = await CreateLogAsync(kaseId, "PDF Log", "Some content here.");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=pdf");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
+
+        var disposition = response.Content.Headers.ContentDisposition;
+        Assert.NotNull(disposition);
+        Assert.EndsWith(".pdf", disposition!.FileName?.Trim('"'));
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        Assert.True(bytes.Length > 0, "PDF should be non-empty");
+        // PDF magic bytes: %PDF
+        Assert.Equal((byte)'%', bytes[0]);
+        Assert.Equal((byte)'P', bytes[1]);
+        Assert.Equal((byte)'D', bytes[2]);
+        Assert.Equal((byte)'F', bytes[3]);
+    }
+
+    [Fact]
+    public async Task Export_Pdf_ContentDispositionHeaderPresent()
+    {
+        var kaseId = await CreateKaseAsync("Kase");
+        var logId  = await CreateLogAsync(kaseId, "PDF Disposition Log", "content");
+
+        var response = await _client.GetAsync($"/api/logs/{logId}/export?format=pdf");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var disposition = response.Content.Headers.ContentDisposition;
+        Assert.NotNull(disposition);
+        Assert.Equal("attachment", disposition!.DispositionType);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/logs/{id}/export?format=markdown|pdf` endpoint on `LogsController`
- Creates `ILogExportService` + `LogExportService` mirroring the existing Kase export pattern
- Markdown export includes title, Kase name, tags, version count, created/last-edited timestamps, and full log content with `/api/images/UID` URLs rewritten to `/data/images/UID.ext`
- PDF export uses QuestPDF with title/metadata header, paginated body, and inline embedded images
- Filename slugged as `log-{title-slug}.md` / `log-{title-slug}.pdf`
- Export section added to Log settings panel (between Info and Delete), with **Export as Markdown** and **Export as PDF** buttons that trigger an immediate download
- `logs.export(id, format)` added to the API client following the same blob-download pattern as `kases.export`
- 12 xUnit integration tests covering 404, 400, markdown content correctness, PDF magic bytes, and Content-Disposition headers — all 143 tests pass

## Test plan

- [ ] Open a Log, open settings panel, verify Export section appears between Info and Delete
- [ ] Click Export as Markdown — file downloads as `log-{slug}.md` containing title, Kase name, tags, timestamps, and full content
- [ ] Click Export as PDF — file downloads as `log-{slug}.pdf` and opens cleanly
- [ ] `GET /api/logs/{unknown-id}/export` returns 404
- [ ] `GET /api/logs/{id}/export?format=xlsx` returns 400
- [ ] All 143 backend tests pass: `dotnet test tests/KaseLog.Api.Tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)