### PR TITLE
fix: font consistency audit fixes

### DIFF
--- a/src/kaselog-ui/src/components/TiptapEditor.tsx
+++ b/src/kaselog-ui/src/components/TiptapEditor.tsx
@@ -115,7 +115,7 @@ function TbBtn({
         minWidth: 26,
         textAlign: 'center',
         whiteSpace: 'nowrap',
-        lineHeight: 1,
+        lineHeight: 1.5,
         flexShrink: 0,
         fontFamily: 'var(--font)',
         transition: 'all 0.12s',

--- a/src/kaselog-ui/src/pages/CollectionItemPage.tsx
+++ b/src/kaselog-ui/src/pages/CollectionItemPage.tsx
@@ -755,7 +755,7 @@ export default function CollectionItemPage() {
         <button
           onClick={() => navigate(`/collections/${collectionId}`)}
           style={{
-            fontSize: 'var(--text-sm)', color: 'var(--text-tertiary)', cursor: 'pointer',
+            fontSize: 'var(--text-sm)', fontWeight: 500, color: 'var(--text-tertiary)', cursor: 'pointer',
             padding: '4px 8px', borderRadius: 5, background: 'transparent',
             border: 'none', fontFamily: 'inherit',
           }}

--- a/src/kaselog-ui/src/pages/CollectionsIndexPage.tsx
+++ b/src/kaselog-ui/src/pages/CollectionsIndexPage.tsx
@@ -38,7 +38,7 @@ export default function CollectionsIndexPage() {
         padding: '0 1.25rem', gap: '0.75rem',
         background: 'var(--bg)', flexShrink: 0,
       }}>
-        <div style={{ fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--text-primary)' }}>
+        <div style={{ fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--text-primary)', letterSpacing: '-0.34px' }}>
           Collections
         </div>
         {!loading && (

--- a/src/kaselog-ui/src/pages/KaseListPage.tsx
+++ b/src/kaselog-ui/src/pages/KaseListPage.tsx
@@ -472,7 +472,7 @@ function KaseRow({ kase, isLast, onPinToggle, onManage, isMedium = false }: Kase
 
         {/* Latest log preview */}
         {kase.latestLogTitle ? (
-          <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-tertiary)', marginBottom: 3, lineHeight: 1.4 }}>
+          <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-tertiary)', marginBottom: 3, lineHeight: 1.5 }}>
             <span style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>{kase.latestLogTitle}</span>
             {kase.latestLogPreview && (
               <span> — {kase.latestLogPreview}</span>

--- a/src/kaselog-ui/src/pages/LogViewPage.tsx
+++ b/src/kaselog-ui/src/pages/LogViewPage.tsx
@@ -436,6 +436,7 @@ export default function LogViewPage() {
           onClick={() => navigate(`/kases/${log.kaseId}`)}
           style={{
             fontSize: 'var(--text-base)',
+            fontWeight: 500,
             color: 'var(--text-tertiary)',
             cursor: 'pointer',
             padding: '4px 8px',

--- a/src/kaselog-ui/src/pages/ProfilePage.tsx
+++ b/src/kaselog-ui/src/pages/ProfilePage.tsx
@@ -76,7 +76,7 @@ export default function ProfilePage() {
     fontWeight: 600,
     color: 'var(--text-secondary)',
     textTransform: 'uppercase',
-    letterSpacing: '0.07em',
+    letterSpacing: '0.08em',
     marginBottom: '0.4rem',
   }
 
@@ -103,6 +103,7 @@ export default function ProfilePage() {
             border: 'none',
             cursor: 'pointer',
             fontSize: 'var(--text-base)',
+            fontWeight: 500,
             color: 'var(--text-secondary)',
             fontFamily: 'var(--font)',
             padding: '4px 6px',


### PR DESCRIPTION
## Summary
- **Fix 1**: Collections page title — add `letter-spacing: -0.34px` to match All Kases and Profile titles
- **Fix 3**: Back buttons on Profile, LogView, and CollectionItem pages — bump `font-weight` from 400 → 500 to signal interactivity
- **Fix 4**: Profile form labels — align `letter-spacing` from `0.07em` → `0.08em` (0.84px → 0.96px) to match nav section labels (KASES, COLLECTIONS)
- **Fix 5**: Editor toolbar buttons (TiptapEditor) — fix `line-height: 1` → `1.5` so 12px buttons follow the app's standard 1.5× ratio
- **Fix 7**: Log preview title/subtitle in kase cards — fix `line-height: 1.4` → `1.5` to match all other `--text-sm` elements

Fixes 2 (active sidebar weight) and 6 (count label concatenation) were not applied — the code already implements `fontWeight: active ? 500 : 400` correctly, and count labels already include spaces between number and word.

## Test plan
- [ ] Visit `/collections` — page title "Collections" should visually match the weight/spacing of "All Kases" and "Profile" titles
- [ ] Visit `/profile` — "← Back" button should render at w500 and form labels should have consistent spacing with nav section headers
- [ ] Open any log (`/logs/:id`) — breadcrumb back button should render at w500
- [ ] Open any collection item — back button should render at w500
- [ ] Open any log editor — toolbar buttons (H1, H2, etc.) should have proper vertical breathing room
- [ ] Visit `/kases` — log preview lines in kase cards should have consistent line-height with surrounding text

🤖 Generated with [Claude Code](https://claude.com/claude-code)