### PR TITLE
fix: move App Settings button to bottom nav between Profile and Search

### DIFF
--- a/src/kaselog-ui/src/App.tsx
+++ b/src/kaselog-ui/src/App.tsx
@@ -10,6 +10,7 @@ import CollectionListPage from './pages/CollectionListPage'
 import CollectionDesignerPage from './pages/CollectionDesignerPage'
 import NewCollectionPage from './pages/NewCollectionPage'
 import CollectionItemPage from './pages/CollectionItemPage'
+import SettingsPage from './pages/SettingsPage'
 
 // Registered routes (all paths the frontend handles):
 //   /                          → KaseListPage   (index)
@@ -18,6 +19,7 @@ import CollectionItemPage from './pages/CollectionItemPage'
 //   /logs/:id                  → LogViewPage
 //   /search                    → SearchPage
 //   /profile                   → ProfilePage
+//   /settings                  → SettingsPage
 //   /collections               → CollectionsIndexPage
 //   /collections/new           → NewCollectionPage
 //   /collections/:id           → CollectionListPage
@@ -35,6 +37,7 @@ const router = createBrowserRouter([
       { path: '/logs/:id', element: <LogViewPage /> },
       { path: '/search', element: <SearchPage /> },
       { path: '/profile', element: <ProfilePage /> },
+      { path: '/settings', element: <SettingsPage /> },
       { path: '/collections', element: <CollectionsIndexPage /> },
       { path: '/collections/new', element: <NewCollectionPage /> },
       { path: '/collections/:id', element: <CollectionListPage /> },

--- a/src/kaselog-ui/src/components/LeftNav.tsx
+++ b/src/kaselog-ui/src/components/LeftNav.tsx
@@ -271,54 +271,6 @@ export default function LeftNav({ onSearchOpen }: LeftNavProps) {
           </div>
         </div>
 
-        {/* App Settings pin — always visible, above scrollable sections */}
-        <div style={{ borderBottom: '1px solid var(--border)', padding: '0.4rem 0.5rem', flexShrink: 0 }}>
-          <button
-            data-testid="nav-settings-btn"
-            onClick={() => navigate('/settings')}
-            aria-label="App Settings"
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.5rem',
-              padding: '0.4rem 0.55rem',
-              borderRadius: 7,
-              background: isSettingsActive ? 'var(--accent-light)' : 'transparent',
-              border: 'none',
-              cursor: 'pointer',
-              width: '100%',
-              fontFamily: 'var(--font)',
-            }}
-          >
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M8 5a3 3 0 1 0 0 6A3 3 0 0 0 8 5ZM6 8a2 2 0 1 1 4 0A2 2 0 0 1 6 8Z"
-                fill={isSettingsActive ? 'var(--accent-text)' : 'var(--text-tertiary)'}
-              />
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M8 1a.75.75 0 0 1 .728.568l.254 1.02a5.1 5.1 0 0 1 .954.554l1.008-.308a.75.75 0 0 1 .816.302l1 1.732a.75.75 0 0 1-.144.944l-.774.692a5.14 5.14 0 0 1 0 1.392l.774.692a.75.75 0 0 1 .144.944l-1 1.732a.75.75 0 0 1-.816.302l-1.008-.308a5.1 5.1 0 0 1-.954.554l-.254 1.02A.75.75 0 0 1 8 15a.75.75 0 0 1-.728-.568l-.254-1.02a5.1 5.1 0 0 1-.954-.554l-1.008.308a.75.75 0 0 1-.816-.302l-1-1.732a.75.75 0 0 1 .144-.944l.774-.692a5.14 5.14 0 0 1 0-1.392l-.774-.692a.75.75 0 0 1-.144-.944l1-1.732a.75.75 0 0 1 .816-.302l1.008.308a5.1 5.1 0 0 1 .954-.554l.254-1.02A.75.75 0 0 1 8 1Z"
-                fill={isSettingsActive ? 'var(--accent-text)' : 'var(--text-tertiary)'}
-              />
-            </svg>
-            <span style={{
-              fontSize: 'var(--text-sm)',
-              color: isSettingsActive ? 'var(--accent-text)' : 'var(--text-secondary)',
-              fontWeight: isSettingsActive ? 500 : 400,
-              flex: 1,
-              textAlign: 'left',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}>
-              App Settings
-            </span>
-          </button>
-        </div>
-
         {/* Nav body — scrollable */}
         <div style={{ flex: 1, overflowY: 'auto' }}>
 
@@ -557,6 +509,32 @@ export default function LeftNav({ onSearchOpen }: LeftNavProps) {
             </div>
             <span style={{ fontSize: 'var(--text-sm)', color: 'var(--text-secondary)', flex: 1, textAlign: 'left', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
               {displayName}
+            </span>
+          </button>
+
+          <button
+            data-testid="nav-settings-btn"
+            onClick={() => navigate('/settings')}
+            aria-label="App Settings"
+            style={{
+              display: 'flex', alignItems: 'center', gap: '0.5rem',
+              padding: '0.4rem 0.65rem', borderRadius: 7,
+              background: isSettingsActive ? 'var(--accent-light)' : 'transparent',
+              border: 'none', cursor: 'pointer', width: '100%', fontFamily: 'var(--font)',
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
+              <path fillRule="evenodd" clipRule="evenodd" d="M8 5a3 3 0 1 0 0 6A3 3 0 0 0 8 5ZM6 8a2 2 0 1 1 4 0A2 2 0 0 1 6 8Z" fill={isSettingsActive ? 'var(--accent-text)' : 'var(--text-tertiary)'} />
+              <path fillRule="evenodd" clipRule="evenodd" d="M8 1a.75.75 0 0 1 .728.568l.254 1.02a5.1 5.1 0 0 1 .954.554l1.008-.308a.75.75 0 0 1 .816.302l1 1.732a.75.75 0 0 1-.144.944l-.774.692a5.14 5.14 0 0 1 0 1.392l.774.692a.75.75 0 0 1 .144.944l-1 1.732a.75.75 0 0 1-.816.302l-1.008-.308a5.1 5.1 0 0 1-.954.554l-.254 1.02A.75.75 0 0 1 8 15a.75.75 0 0 1-.728-.568l-.254-1.02a5.1 5.1 0 0 1-.954-.554l-1.008.308a.75.75 0 0 1-.816-.302l-1-1.732a.75.75 0 0 1 .144-.944l.774-.692a5.14 5.14 0 0 1 0-1.392l-.774-.692a.75.75 0 0 1-.144-.944l1-1.732a.75.75 0 0 1 .816-.302l1.008.308a5.1 5.1 0 0 1 .954-.554l.254-1.02A.75.75 0 0 1 8 1Z" fill={isSettingsActive ? 'var(--accent-text)' : 'var(--text-tertiary)'} />
+            </svg>
+            <span style={{
+              fontSize: 'var(--text-sm)',
+              color: isSettingsActive ? 'var(--accent-text)' : 'var(--text-secondary)',
+              fontWeight: isSettingsActive ? 500 : 400,
+              flex: 1, textAlign: 'left',
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+            }}>
+              App Settings
             </span>
           </button>
 

--- a/src/kaselog-ui/src/components/LeftNav.tsx
+++ b/src/kaselog-ui/src/components/LeftNav.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { useMatch, useNavigate } from 'react-router-dom'
+import { useMatch, useNavigate, useLocation } from 'react-router-dom'
 import { useKases } from '../contexts/KasesContext'
 import { useCollections } from '../contexts/CollectionsContext'
 import { useUser } from '../contexts/UserContext'
@@ -123,6 +123,9 @@ export default function LeftNav({ onSearchOpen }: LeftNavProps) {
   const collectionMatch = useMatch('/collections/:id')
   const activeKaseId = kaseMatch?.params.id
   const activeCollectionId = collectionMatch?.params.id
+
+  const location = useLocation()
+  const isSettingsActive = location.pathname === '/settings' || location.pathname.startsWith('/settings/')
 
   const [kasesOpen, setKasesOpen] = useState(true)
   const [collectionsOpen, setCollectionsOpen] = useState(true)
@@ -266,6 +269,54 @@ export default function LeftNav({ onSearchOpen }: LeftNavProps) {
           <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-tertiary)', marginTop: 1, letterSpacing: '0.02em' }}>
             private ops journal
           </div>
+        </div>
+
+        {/* App Settings pin — always visible, above scrollable sections */}
+        <div style={{ borderBottom: '1px solid var(--border)', padding: '0.4rem 0.5rem', flexShrink: 0 }}>
+          <button
+            data-testid="nav-settings-btn"
+            onClick={() => navigate('/settings')}
+            aria-label="App Settings"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              padding: '0.4rem 0.55rem',
+              borderRadius: 7,
+              background: isSettingsActive ? 'var(--accent-light)' : 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              width: '100%',
+              fontFamily: 'var(--font)',
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true" style={{ flexShrink: 0 }}>
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M8 5a3 3 0 1 0 0 6A3 3 0 0 0 8 5ZM6 8a2 2 0 1 1 4 0A2 2 0 0 1 6 8Z"
+                fill={isSettingsActive ? 'var(--accent-text)' : 'var(--text-tertiary)'}
+              />
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M8 1a.75.75 0 0 1 .728.568l.254 1.02a5.1 5.1 0 0 1 .954.554l1.008-.308a.75.75 0 0 1 .816.302l1 1.732a.75.75 0 0 1-.144.944l-.774.692a5.14 5.14 0 0 1 0 1.392l.774.692a.75.75 0 0 1 .144.944l-1 1.732a.75.75 0 0 1-.816.302l-1.008-.308a5.1 5.1 0 0 1-.954.554l-.254 1.02A.75.75 0 0 1 8 15a.75.75 0 0 1-.728-.568l-.254-1.02a5.1 5.1 0 0 1-.954-.554l-1.008.308a.75.75 0 0 1-.816-.302l-1-1.732a.75.75 0 0 1 .144-.944l.774-.692a5.14 5.14 0 0 1 0-1.392l-.774-.692a.75.75 0 0 1-.144-.944l1-1.732a.75.75 0 0 1 .816-.302l1.008.308a5.1 5.1 0 0 1 .954-.554l.254-1.02A.75.75 0 0 1 8 1Z"
+                fill={isSettingsActive ? 'var(--accent-text)' : 'var(--text-tertiary)'}
+              />
+            </svg>
+            <span style={{
+              fontSize: 'var(--text-sm)',
+              color: isSettingsActive ? 'var(--accent-text)' : 'var(--text-secondary)',
+              fontWeight: isSettingsActive ? 500 : 400,
+              flex: 1,
+              textAlign: 'left',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}>
+              App Settings
+            </span>
+          </button>
         </div>
 
         {/* Nav body — scrollable */}

--- a/src/kaselog-ui/src/pages/SettingsPage.tsx
+++ b/src/kaselog-ui/src/pages/SettingsPage.tsx
@@ -1,0 +1,333 @@
+import { useState } from 'react'
+
+type TabId = 'workspace' | 'users' | 'notifications' | 'integrations' | 'security' | 'data'
+
+interface TabDef {
+  id: TabId
+  label: string
+  icon: string
+}
+
+const TABS: TabDef[] = [
+  { id: 'workspace',     label: 'Workspace',        icon: '🗂️' },
+  { id: 'users',         label: 'Users',             icon: '👥' },
+  { id: 'notifications', label: 'Notifications',     icon: '🔔' },
+  { id: 'integrations',  label: 'Integrations',      icon: '🔌' },
+  { id: 'security',      label: 'Security & Access', icon: '🔒' },
+  { id: 'data',          label: 'Data',              icon: '💾' },
+]
+
+// ── Badge ─────────────────────────────────────────────────────────────────────
+
+type BadgeVariant = 'soon' | 'planned' | 'destructive'
+
+const BADGE_LABEL: Record<BadgeVariant, string> = {
+  soon:        'soon',
+  planned:     'planned',
+  destructive: 'destructive',
+}
+
+function Badge({ variant }: { variant: BadgeVariant }) {
+  const style: React.CSSProperties =
+    variant === 'soon'
+      ? { background: 'var(--accent-light)', color: 'var(--accent-text)' }
+      : variant === 'planned'
+      ? { background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)' }
+      : { background: '#FCEBEB', color: '#A32D2D' }
+
+  return (
+    <span
+      data-testid={`badge-${variant}`}
+      style={{
+        fontSize: 'var(--text-xs)',
+        fontWeight: 600,
+        padding: '2px 8px',
+        borderRadius: 99,
+        flexShrink: 0,
+        ...style,
+      }}
+    >
+      {BADGE_LABEL[variant]}
+    </span>
+  )
+}
+
+// ── Coming-soon card ──────────────────────────────────────────────────────────
+
+function ComingSoonCard({ title, badge }: { title: string; badge: BadgeVariant }) {
+  return (
+    <div style={{
+      background: 'var(--bg)',
+      border: '1px solid var(--border)',
+      borderRadius: 10,
+      padding: '1rem 1.25rem',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: '1rem',
+    }}>
+      <span style={{ fontSize: 'var(--text-sm)', fontWeight: 500, color: 'var(--text-primary)' }}>
+        {title}
+      </span>
+      <Badge variant={badge} />
+    </div>
+  )
+}
+
+// ── Section wrapper ───────────────────────────────────────────────────────────
+
+function Section({ title, description, children }: {
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <h1 style={{
+          fontSize: 'var(--text-base)', fontWeight: 600,
+          color: 'var(--text-primary)', marginBottom: '0.35rem',
+        }}>
+          {title}
+        </h1>
+        <p style={{ fontSize: 'var(--text-sm)', color: 'var(--text-secondary)' }}>
+          {description}
+        </p>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// ── Tab panels ────────────────────────────────────────────────────────────────
+
+function WorkspacePanel() {
+  return (
+    <Section
+      title="Workspace"
+      description="Configure workspace-level settings and templates for your instance."
+    >
+      <ComingSoonCard title="Kase Templates" badge="soon" />
+      <ComingSoonCard title="Shareable Read-Only Links" badge="planned" />
+    </Section>
+  )
+}
+
+function UsersPanel() {
+  return (
+    <Section
+      title="Users"
+      description="Manage user accounts and access roles for this instance."
+    >
+      <p style={{
+        fontSize: 'var(--text-sm)', color: 'var(--text-tertiary)',
+        fontStyle: 'italic', marginBottom: '0.25rem',
+      }}>
+        Multi-user support is on the roadmap
+      </p>
+      <ComingSoonCard title="User Accounts" badge="planned" />
+      <ComingSoonCard title="Roles & Permissions" badge="planned" />
+    </Section>
+  )
+}
+
+function NotificationsPanel() {
+  return (
+    <Section
+      title="Notifications"
+      description="Configure outbound alerts and event-driven notification triggers."
+    >
+      <ComingSoonCard title="Outbound Webhooks" badge="soon" />
+      <ComingSoonCard title="Email Configuration" badge="planned" />
+      <ComingSoonCard title="Event Triggers" badge="planned" />
+    </Section>
+  )
+}
+
+function IntegrationsPanel() {
+  return (
+    <Section
+      title="Integrations"
+      description="Connect KaseLog to external services and protocols."
+    >
+      <ComingSoonCard title="MCP Server Access" badge="soon" />
+      <ComingSoonCard title="OAuth Provider Configuration" badge="planned" />
+    </Section>
+  )
+}
+
+function SecurityPanel() {
+  return (
+    <Section
+      title="Security & Access"
+      description="Control network access, CORS policy, and API credentials."
+    >
+      <ComingSoonCard title="URL & CORS Configuration" badge="soon" />
+      <ComingSoonCard title="API Key Management" badge="planned" />
+    </Section>
+  )
+}
+
+function DataPanel() {
+  return (
+    <div>
+      <Section
+        title="Data"
+        description="Backup, restore, and migrate your KaseLog data."
+      >
+        <ComingSoonCard title="Backup" badge="soon" />
+        <ComingSoonCard title="Restore" badge="planned" />
+        <ComingSoonCard title="Import from External Sources" badge="planned" />
+      </Section>
+
+      {/* Danger zone */}
+      <div
+        data-testid="danger-zone"
+        style={{
+          marginTop: '2rem',
+          border: '1px solid #F09595',
+          borderRadius: 10,
+          background: '#FEF5F5',
+          overflow: 'hidden',
+        }}
+      >
+        <div style={{
+          padding: '0.65rem 1.25rem',
+          borderBottom: '1px solid #F09595',
+        }}>
+          <span style={{ fontSize: 'var(--text-sm)', fontWeight: 600, color: '#A32D2D' }}>
+            Danger Zone
+          </span>
+        </div>
+        <div style={{ padding: '1rem 1.25rem' }}>
+          <div style={{
+            background: 'white',
+            border: '1px solid #F09595',
+            borderRadius: 8,
+            padding: '1rem 1.25rem',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '1rem',
+          }}>
+            <span style={{ fontSize: 'var(--text-sm)', fontWeight: 500, color: '#A32D2D' }}>
+              Delete All Data
+            </span>
+            <span style={{
+              background: '#FCEBEB', color: '#A32D2D',
+              fontSize: 'var(--text-xs)', fontWeight: 600,
+              padding: '2px 8px', borderRadius: 99, flexShrink: 0,
+            }}>
+              destructive
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const PANELS: Record<TabId, React.FC> = {
+  workspace:     WorkspacePanel,
+  users:         UsersPanel,
+  notifications: NotificationsPanel,
+  integrations:  IntegrationsPanel,
+  security:      SecurityPanel,
+  data:          DataPanel,
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function SettingsPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('workspace')
+
+  const Panel = PANELS[activeTab]
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+
+      {/* Top bar */}
+      <div style={{
+        height: 48, minHeight: 48,
+        borderBottom: '1px solid var(--border)',
+        display: 'flex', alignItems: 'center',
+        padding: '0 1.25rem', gap: '0.75rem',
+        background: 'var(--bg)', flexShrink: 0,
+      }}>
+        <span style={{ fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--text-primary)' }}>
+          App Settings
+        </span>
+        <div style={{ flex: 1 }} />
+        <span style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 'var(--text-xs)',
+          color: 'var(--text-tertiary)',
+          padding: '2px 8px',
+          background: 'var(--bg-secondary)',
+          border: '1px solid var(--border)',
+          borderRadius: 99,
+        }}>
+          v0.1 — framework
+        </span>
+      </div>
+
+      {/* Tab bar */}
+      <div
+        role="tablist"
+        aria-label="Settings tabs"
+        style={{
+          display: 'flex',
+          borderBottom: '1px solid var(--border)',
+          background: 'var(--bg)',
+          flexShrink: 0,
+          padding: '0 1.25rem',
+          gap: '0.1rem',
+          overflowX: 'auto',
+        }}
+      >
+        {TABS.map(tab => {
+          const isActive = activeTab === tab.id
+          return (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={isActive}
+              data-testid={`settings-tab-${tab.id}`}
+              onClick={() => setActiveTab(tab.id)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.35rem',
+                padding: '0.6rem 0.75rem',
+                fontSize: 'var(--text-sm)',
+                fontWeight: isActive ? 500 : 400,
+                color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)',
+                background: 'none',
+                border: 'none',
+                borderBottom: isActive ? '2px solid var(--accent)' : '2px solid transparent',
+                cursor: 'pointer',
+                fontFamily: 'var(--font)',
+                whiteSpace: 'nowrap',
+                marginBottom: -1,
+                transition: 'color 0.1s',
+              }}
+            >
+              <span aria-hidden="true">{tab.icon}</span>
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Settings body */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '2rem 2.5rem' }}>
+        <div style={{ maxWidth: 820 }}>
+          <Panel />
+        </div>
+      </div>
+
+    </div>
+  )
+}

--- a/src/kaselog-ui/src/test/SettingsPage.test.tsx
+++ b/src/kaselog-ui/src/test/SettingsPage.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import SettingsPage from '../pages/SettingsPage'
+import LeftNav from '../components/LeftNav'
+import { KasesProvider } from '../contexts/KasesContext'
+import { CollectionsProvider } from '../contexts/CollectionsContext'
+import { ThemeProvider } from '../contexts/ThemeContext'
+import { UserProvider } from '../contexts/UserContext'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../api/client', () => ({
+  kases: {
+    list:   vi.fn(),
+    pin:    vi.fn(),
+    unpin:  vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  collections: {
+    list: vi.fn(),
+  },
+  user: {
+    get:    vi.fn(),
+    update: vi.fn(),
+  },
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+import { kases as kasesApi, collections as collectionsApi, user as userApi } from '../api/client'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderSettings() {
+  return render(
+    <MemoryRouter initialEntries={['/settings']}>
+      <Routes>
+        <Route path="*" element={<SettingsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function renderNavAtPath(path: string) {
+  vi.mocked(kasesApi.list).mockResolvedValue([])
+  vi.mocked(collectionsApi.list).mockResolvedValue([])
+  vi.mocked(userApi.get).mockResolvedValue({
+    id: 'u1', firstName: null, lastName: null, email: null,
+    theme: 'light', accent: 'teal', fontSize: 'medium',
+    createdAt: '', updatedAt: '',
+  })
+
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="*" element={
+          <ThemeProvider>
+            <UserProvider>
+              <KasesProvider>
+                <CollectionsProvider>
+                  <LeftNav onSearchOpen={vi.fn()} />
+                </CollectionsProvider>
+              </KasesProvider>
+            </UserProvider>
+          </ThemeProvider>
+        } />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// ── SettingsPage — basic render ───────────────────────────────────────────────
+
+describe('SettingsPage — render', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNavigate.mockReset()
+  })
+
+  it('renders without errors', () => {
+    renderSettings()
+    expect(screen.getByText('App Settings')).toBeInTheDocument()
+  })
+
+  it('renders the version badge', () => {
+    renderSettings()
+    expect(screen.getByText('v0.1 — framework')).toBeInTheDocument()
+  })
+})
+
+// ── SettingsPage — tab bar ────────────────────────────────────────────────────
+
+describe('SettingsPage — tab bar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNavigate.mockReset()
+  })
+
+  it('renders all six tabs', () => {
+    renderSettings()
+    const tablist = screen.getByRole('tablist')
+    const tabs = within(tablist).getAllByRole('tab')
+    expect(tabs).toHaveLength(6)
+  })
+
+  it('renders each expected tab label', () => {
+    renderSettings()
+    expect(screen.getByTestId('settings-tab-workspace')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-tab-users')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-tab-notifications')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-tab-integrations')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-tab-security')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-tab-data')).toBeInTheDocument()
+  })
+
+  it('default active tab on mount is Workspace', () => {
+    renderSettings()
+    const workspaceTab = screen.getByTestId('settings-tab-workspace')
+    expect(workspaceTab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('all other tabs are not selected on mount', () => {
+    renderSettings()
+    const inactiveTabs = ['users', 'notifications', 'integrations', 'security', 'data']
+    for (const id of inactiveTabs) {
+      expect(screen.getByTestId(`settings-tab-${id}`)).toHaveAttribute('aria-selected', 'false')
+    }
+  })
+
+  it('clicking a tab activates it and deactivates the previously active tab', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    await user.click(screen.getByTestId('settings-tab-users'))
+
+    expect(screen.getByTestId('settings-tab-users')).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('settings-tab-workspace')).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('clicking each tab in turn activates it', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    const tabIds: string[] = ['workspace', 'users', 'notifications', 'integrations', 'security', 'data']
+
+    for (const id of tabIds) {
+      await user.click(screen.getByTestId(`settings-tab-${id}`))
+      expect(screen.getByTestId(`settings-tab-${id}`)).toHaveAttribute('aria-selected', 'true')
+      // All others should be inactive
+      for (const otherId of tabIds.filter(t => t !== id)) {
+        expect(screen.getByTestId(`settings-tab-${otherId}`)).toHaveAttribute('aria-selected', 'false')
+      }
+    }
+  })
+})
+
+// ── SettingsPage — panel content ──────────────────────────────────────────────
+
+describe('SettingsPage — Workspace panel (default)', () => {
+  it('shows Kase Templates and Shareable Read-Only Links cards', () => {
+    renderSettings()
+    expect(screen.getByText('Kase Templates')).toBeInTheDocument()
+    expect(screen.getByText('Shareable Read-Only Links')).toBeInTheDocument()
+  })
+})
+
+describe('SettingsPage — Data panel danger zone', () => {
+  it('shows danger zone when Data tab is active', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    await user.click(screen.getByTestId('settings-tab-data'))
+
+    expect(screen.getByTestId('danger-zone')).toBeInTheDocument()
+    expect(screen.getByText('Delete All Data')).toBeInTheDocument()
+  })
+})
+
+// ── LeftNav — App Settings button ────────────────────────────────────────────
+
+describe('LeftNav — App Settings button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNavigate.mockReset()
+  })
+
+  it('renders the settings button in the left nav', () => {
+    renderNavAtPath('/')
+    expect(screen.getByTestId('nav-settings-btn')).toBeInTheDocument()
+  })
+
+  it('settings button is present on a kase route', () => {
+    renderNavAtPath('/kases/some-id')
+    expect(screen.getByTestId('nav-settings-btn')).toBeInTheDocument()
+  })
+
+  it('settings button is present on a collections route', () => {
+    renderNavAtPath('/collections')
+    expect(screen.getByTestId('nav-settings-btn')).toBeInTheDocument()
+  })
+
+  it('settings button navigates to /settings on click', async () => {
+    const user = userEvent.setup()
+    renderNavAtPath('/')
+
+    await user.click(screen.getByTestId('nav-settings-btn'))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/settings')
+  })
+
+  it('settings button has active styling when current route is /settings', () => {
+    renderNavAtPath('/settings')
+
+    const btn = screen.getByTestId('nav-settings-btn')
+    // Active: background is accent-light, text accent-text
+    // We test via the computed style string containing the CSS variable
+    expect(btn).toHaveStyle({ background: 'var(--accent-light)' })
+  })
+
+  it('settings button does not have active styling on non-settings route', () => {
+    renderNavAtPath('/')
+
+    const btn = screen.getByTestId('nav-settings-btn')
+    expect(btn).not.toHaveStyle({ background: 'var(--accent-light)' })
+  })
+})


### PR DESCRIPTION
## Summary
- Moves the App Settings button from above the Kases section to the bottom nav, between the Profile button and the Search bar
- Consistent placement with other pinned bottom-nav actions; active styling (accent-light background) still applies on `/settings` routes

## Test plan
- [x] All 248 tests pass
- [x] Visually verified in preview — button appears between Profile and Search logs
- [x] Active accent styling confirmed when on /settings route

🤖 Generated with [Claude Code](https://claude.com/claude-code)